### PR TITLE
Convert auth_data_length to a signed integer

### DIFF
--- a/src/mysql/packets.cr
+++ b/src/mysql/packets.cr
@@ -24,7 +24,7 @@ module MySql::Protocol
 
       auth_plugin_data_length = packet.read_byte!
       packet.read_byte_array(10)
-      packet.read(auth_data[8, {13, auth_plugin_data_length - 8}.max - 1])
+      packet.read(auth_data[8, {13, auth_plugin_data_length.to_i16 - 8}.max - 1])
       packet.read_byte!
       packet.read_string
 


### PR DESCRIPTION
Created patch to fix #3 

I chose to use `.to_i16` because it keeps that line looking like the mysql protocol spec documentation: <https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::Handshake>
