### PR TITLE
implement TextProtocol for unprepared statements without arguments

### DIFF
--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -137,7 +137,11 @@ class MySql::Connection < DB::Connection
     end
   end
 
-  def build_statement(query)
+  def build_prepared_statement(query)
     MySql::Statement.new(self, query)
+  end
+
+  def build_unprepared_statement(query)
+    MySql::UnpreparedStatement.new(self, query)
   end
 end

--- a/src/mysql/text_result_set.cr
+++ b/src/mysql/text_result_set.cr
@@ -1,0 +1,84 @@
+# Implementation of ProtocolText::Resultset.
+# Used for unprepared statements.
+class MySql::TextResultSet < DB::ResultSet
+  getter columns
+
+  @conn : MySql::Connection
+  @row_packet : MySql::ReadPacket?
+  @header : UInt8
+
+  def initialize(statement, column_count)
+    super(statement)
+    @conn = statement.connection.as(MySql::Connection)
+
+    columns = @columns = [] of ColumnSpec
+    @conn.read_column_definitions(columns, column_count)
+
+    @column_index = 0 # next column index to return
+
+    @header = 0u8
+    @eof_reached = false
+  end
+
+  def do_close
+    super
+
+    while move_next
+    end
+
+    if row_packet = @row_packet
+      row_packet.discard
+    end
+  end
+
+  def move_next : Bool
+    return false if @eof_reached
+
+    # skip previous row_packet
+    if row_packet = @row_packet
+      row_packet.discard
+    end
+
+    @row_packet = row_packet = @conn.build_read_packet
+
+    @header = row_packet.read_byte!
+    if @header == 0xfe # EOF
+      @eof_reached = true
+      return false
+    end
+
+    @column_index = 0
+    # TODO remove row_packet.read(@null_bitmap_slice)
+    return true
+  end
+
+  def column_count : Int32
+    @columns.size
+  end
+
+  def column_name(index : Int32) : String
+    @columns[index].name
+  end
+
+  def read
+    row_packet = @row_packet.not_nil!
+
+    is_nil = @header == 0xfb
+    col = @column_index
+    @column_index += 1
+    if is_nil
+      nil
+    else
+      length = row_packet.read_lenenc_int(@header)
+      val = row_packet.read_string(length)
+      val = @columns[col].column_type.parse(val)
+
+      # http://dev.mysql.com/doc/internals/en/character-set.html
+      if val.is_a?(Slice(UInt8)) && @columns[col].character_set != 63
+        ::String.new(val)
+      else
+        val
+      end
+    end
+  end
+end

--- a/src/mysql/unprepared_statement.cr
+++ b/src/mysql/unprepared_statement.cr
@@ -1,0 +1,41 @@
+class MySql::UnpreparedStatement < DB::Statement
+  def initialize(connection, @sql : String)
+    super(connection)
+  end
+
+  protected def conn
+    @connection.as(Connection)
+  end
+
+  protected def perform_query(args : Enumerable) : DB::ResultSet
+    perform_exec_or_query(args).as(DB::ResultSet)
+  end
+
+  protected def perform_exec(args : Enumerable) : DB::ExecResult
+    perform_exec_or_query(args).as(DB::ExecResult)
+  end
+
+  private def perform_exec_or_query(args : Enumerable)
+    raise "exec/query with args is not supported" if args.size > 0
+
+    conn = self.conn
+    conn.write_packet do |packet|
+      packet.write_byte 0x03u8
+      packet << @sql
+      # TODO to support args an interpolation needs to be done
+    end
+
+    conn.read_packet do |packet|
+      case header = packet.read_byte.not_nil!
+      when 255 # err packet
+        conn.handle_err_packet(packet)
+      when 0 # ok packet
+        affected_rows = packet.read_lenenc_int
+        last_insert_id = packet.read_lenenc_int
+        DB::ExecResult.new affected_rows, last_insert_id
+      else
+        MySql::TextResultSet.new(self, packet.read_lenenc_int(header))
+      end
+    end
+  end
+end


### PR DESCRIPTION
ref: crystal-lang/crystal-db#25

* Update `MySql::Connection` to crystal-db/feature/unprepared branch
* Add `TextResultSet` and `UnpreparedStatement` to implement TextProtocol.

mysql text protocol does not support arguments. To proper support them parse/interpolate need to be done. That will come later.

Unprepared statements are needed in order to build support for transactions.
