### PR TITLE
Close underlying socket when closing connection

### DIFF
--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -33,6 +33,11 @@ class MySql::Connection < DB::Connection
     end
   end
 
+  def do_close
+    super
+    @socket.close rescue nil
+  end
+
   # :nodoc:
   def read_ok_or_err
     read_packet do |packet|


### PR DESCRIPTION
Fixes crystal-lang/crystal-db#39

I'm unsure as to whether the `@socket.close` may raise under certain condition and cause issues to the closing of the entire pool. Should we swallow any exceptions from the close, should they happen?