### PR TITLE
Make MYSQL_TYPE_DATETIME packet length to 11

### DIFF
--- a/src/mysql/types.cr
+++ b/src/mysql/types.cr
@@ -159,7 +159,7 @@ abstract struct MySql::Type
   decl_type Time, 0x0bu8
   decl_type DateTime, 0x0cu8, ::Time do
     def self.write(packet, v : ::Time)
-      packet.write_blob UInt8.slice(v.year.to_i16, v.year.to_i16/256, v.month.to_i8, v.day.to_i8, v.hour.to_i8, v.minute.to_i8, v.second.to_i8, v.millisecond*1000, v.millisecond*1000/256, v.millisecond*1000/65536)
+      packet.write_blob UInt8.slice(v.year.to_i16, v.year.to_i16/256, v.month.to_i8, v.day.to_i8, v.hour.to_i8, v.minute.to_i8, v.second.to_i8, v.millisecond*1000, v.millisecond*1000/256, v.millisecond*1000/65536, v.millisecond*1000/65536 v.millisecond*1000/16711425)
     end
 
     def self.read(packet)


### PR DESCRIPTION

According to doc, valid length values are 0, 4, 7, 11.
https://dev.mysql.com/doc/internals/en/binary-protocol-value.html

Sometimes DateTime type param is truncated to `''` by the following param.


```
(Before)
170310  4:15:46	 1899 Connect	root@localhost on jericho
		 1899 Prepare	SELECT posts.* FROM posts WHERE posted_at BETWEEN ? AND ? LIMIT 5
		 1899 Execute	SELECT posts.* FROM posts WHERE posted_at BETWEEN '' AND '2017-03-03 15:59:59' LIMIT 5

(After)
170310  4:15:56	 1900 Connect	root@localhost on jericho
		 1900 Prepare	SELECT posts.* FROM posts WHERE posted_at BETWEEN ? AND ? LIMIT 5
		 1900 Execute	SELECT posts.* FROM posts WHERE posted_at BETWEEN '2017-03-02 16:00:00' AND '2017-03-03 15:59:59' LIMIT 5
```

----
mysql  Ver 14.14 Distrib 5.6.34, for osx10.12 (x86_64) using  EditLine wrapper

Crystal 0.21.1 (2017-03-07) LLVM 3.9.1
