### PR TITLE
added DATE and TIME to driver

### DIFF
--- a/spec/db_spec.cr
+++ b/spec/db_spec.cr
@@ -32,6 +32,9 @@ DB::DriverSpecs(MySql::Any).run do
   sample_value Time.new(2016, 2, 15), "datetime", "TIMESTAMP '2016-02-15 00:00:00.000'"
   sample_value Time.new(2016, 2, 15, 10, 15, 30), "datetime", "TIMESTAMP '2016-02-15 10:15:30.000'"
   sample_value Time.new(2016, 2, 15, 10, 15, 30), "timestamp", "TIMESTAMP '2016-02-15 10:15:30.000'"
+  sample_value Time::Span.new(0), "Time", "TIME('00:00:00')"
+  sample_value Time::Span.new(10, 25, 21), "Time", "TIME('10:25:21')"
+  sample_value Time::Span.new(0, 0, 10, 5, 0), "Time", "TIME('00:10:05.000')"
 
   DB.open db_url do |db|
     # needs to check version, microsecond support >= 5.7

--- a/spec/db_spec.cr
+++ b/spec/db_spec.cr
@@ -32,6 +32,7 @@ DB::DriverSpecs(MySql::Any).run do
   sample_value Time.new(2016, 2, 15), "datetime", "TIMESTAMP '2016-02-15 00:00:00.000'"
   sample_value Time.new(2016, 2, 15, 10, 15, 30), "datetime", "TIMESTAMP '2016-02-15 10:15:30.000'"
   sample_value Time.new(2016, 2, 15, 10, 15, 30), "timestamp", "TIMESTAMP '2016-02-15 10:15:30.000'"
+  sample_value Time.new(2016, 2, 29), "date", "LAST_DAY('2016-02-15')", type_safe_value: false
   sample_value Time::Span.new(0), "Time", "TIME('00:00:00')"
   sample_value Time::Span.new(10, 25, 21), "Time", "TIME('10:25:21')"
   sample_value Time::Span.new(0, 0, 10, 5, 0), "Time", "TIME('00:10:05.000')"

--- a/src/mysql.cr
+++ b/src/mysql.cr
@@ -10,5 +10,5 @@ module MySql
     end
   end
 
-  alias Any = DB::Any | Int16 | Int8
+  alias Any = DB::Any | Int16 | Int8 | Time::Span
 end

--- a/src/mysql/types.cr
+++ b/src/mysql/types.cr
@@ -234,9 +234,13 @@ abstract struct MySql::Type
     def self.parse(str : ::String)
       return ::Time.new(0) if str.starts_with?("0000-00-00")
       begin
-        ::Time.parse(str, "%F %H:%M:%S.%L")
+        begin
+          ::Time.parse(str, "%F %H:%M:%S.%L")
+        rescue
+          ::Time.parse(str, "%F %H:%M:%S")
+        end
       rescue
-        ::Time.parse(str, "%F %H:%M:%S")
+        ::Time.parse(str, "%F")
       end
     end
   end


### PR DESCRIPTION
I've added date and time. The time format isn't quite right as I suspect this should be using a `Time::Span` type as opposed to `Time`. (see https://dev.mysql.com/doc/refman/5.7/en/time.html). However this fixes issues I was having with date and at least allows you to read and write times, you'll just get back time object with year,month,day set to 1,1,1