### PR TITLE
close connection after cleaning up text result set

### DIFF
--- a/spec/db_spec.cr
+++ b/spec/db_spec.cr
@@ -158,7 +158,7 @@ DB::DriverSpecs(MySql::Any).run do
     end
   end
 
-  it "does not close a connection before cleaning up the resultset" do |db|
+  it "does not close a connection before cleaning up the result set" do |db|
     begin
       DB.open db.uri do |db|
         db.query("select 'foo'") do |rs|
@@ -166,6 +166,25 @@ DB::DriverSpecs(MySql::Any).run do
             rs.read(String)
           end
           db.query("select 'bar'") do |rs|
+            rs.each do
+              rs.read(String)
+            end
+          end
+        end
+      end
+    rescue e
+      fail("Expected no exception, but got \"#{e.message}\"")
+    end
+  end
+
+  it "does not close a connection before cleaning up the text result set" do |db|
+    begin
+      DB.open db.uri do |db|
+        db.unprepared.query("select 'foo'") do |rs|
+          rs.each do
+            rs.read(String)
+          end
+          db.unprepared.query("select 'bar'") do |rs|
             rs.each do
               rs.read(String)
             end

--- a/src/mysql/text_result_set.cr
+++ b/src/mysql/text_result_set.cr
@@ -22,14 +22,14 @@ class MySql::TextResultSet < DB::ResultSet
   end
 
   def do_close
-    super
-
     while move_next
     end
 
     if row_packet = @row_packet
       row_packet.discard
     end
+  ensure
+    super
   end
 
   def move_next : Bool


### PR DESCRIPTION
Same problem as with the prepared statements occurred in unprepared statements path as well.