### PR TITLE
fixed #44: use read_fully to avoid incomplete read

### DIFF
--- a/src/mysql/read_packet.cr
+++ b/src/mysql/read_packet.cr
@@ -25,7 +25,7 @@ class MySql::ReadPacket
 
   def read(slice : Bytes)
     return 0 unless @remaining > 0
-    read_bytes = @io.read(slice)
+    read_bytes = @io.read_fully(slice)
     @remaining -= read_bytes
     read_bytes
   rescue IO::EOFError


### PR DESCRIPTION
Fixed #44 

tested with Crystal 0.23.1 [e2a1389] (2017-07-13) LLVM 3.8.1
