### PR TITLE
Send quit packet before closing connection.

### DIFF
--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -35,6 +35,9 @@ class MySql::Connection < DB::Connection
 
   def do_close
     super
+    write_packet(0) do |packet|
+      Protocol::Quit.new.write(packet)
+    end
     @socket.close rescue nil
   end
 

--- a/src/mysql/packets.cr
+++ b/src/mysql/packets.cr
@@ -115,4 +115,10 @@ module MySql::Protocol
       end
     end
   end
+
+  struct Quit
+    def write(packet : MySql::WritePacket)
+      packet.write_byte 1_u8
+    end
+  end
 end


### PR DESCRIPTION
With current driver, MySQL logs:

```
Aborted connection ... to db: ... user: ... host: ... (Got an error reading communication packets)
```

This PR fix it by sending quit packet to MySQL server before closing the connection.