### PR TITLE
Send quit packet before closing connection

### DIFF
--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -35,6 +35,9 @@ class MySql::Connection < DB::Connection
 
   def do_close
     super
+    write_packet(0) do |packet|
+      Protocol::Quit.new.write(packet)
+    end
     @socket.close rescue nil
   end
 

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -35,10 +35,14 @@ class MySql::Connection < DB::Connection
 
   def do_close
     super
-    write_packet(0) do |packet|
-      Protocol::Quit.new.write(packet)
+
+    begin
+      write_packet do |packet|
+        Protocol::Quit.new.write(packet)
+      end
+      @socket.close
+    rescue
     end
-    @socket.close rescue nil
   end
 
   # :nodoc:

--- a/src/mysql/packets.cr
+++ b/src/mysql/packets.cr
@@ -115,4 +115,10 @@ module MySql::Protocol
       end
     end
   end
+
+  struct Quit
+    def write(packet : MySql::WritePacket)
+      packet.write_byte 1_u8
+    end
+  end
 end


### PR DESCRIPTION
Supersedes #57.

Rebased the work of @liuyang1204 onto master and ensures sending the quit command won't raise.