### PR TITLE
Added basic JSON column support

### DIFF
--- a/spec/db_spec.cr
+++ b/spec/db_spec.cr
@@ -49,6 +49,7 @@ DB::DriverSpecs(MySql::Any).run do
       sample_value Time.utc(2016, 2, 15, 10, 15, 30, nanosecond: 543_012_000), "timestamp(6)", "TIMESTAMP '2016-02-15 10:15:30.543012'"
       sample_value Time::Span.new(0, 10, 15, 30, nanoseconds: 543_000_000), "Time(3)", "TIME '10:15:30.543'"
       sample_value Time::Span.new(0, 10, 15, 30, nanoseconds: 543_012_000), "Time(6)", "TIME '10:15:30.543012'"
+      sample_value "{\"example\": \"json\"}", "JSON", "'{\"example\": \"json\"}'"
     end
   end
 

--- a/src/mysql/types.cr
+++ b/src/mysql/types.cr
@@ -60,6 +60,10 @@ abstract struct MySql::Type
     MySql::Type::Null
   end
 
+  def self.type_for(t : ::JSON::Any.class)
+    MySql::Type::Json
+  end
+
   def self.type_for(t)
     raise "MySql::Type does not support #{t} values"
   end
@@ -144,6 +148,7 @@ abstract struct MySql::Type
       nil
     end
   end
+
   decl_type Timestamp, 0x07u8, ::Time do
     def self.write(packet, v : ::Time)
       MySql::Type::DateTime.write(packet, v)
@@ -315,4 +320,24 @@ abstract struct MySql::Type
     end
   end
   decl_type Geometry, 0xffu8
+
+  # Parse the JSON column type
+  decl_type Json, 245_u8, String do
+
+    def self.write(packet, v : String)
+      packet.write_string v
+    end
+
+    def self.write(packet, v : ::JSON::Any)
+      packet.write_string v.to_json
+    end
+
+    def self.read(packet)
+      packet.read_string.lchop("\u0013")
+    end
+
+    def self.parse(str : ::String)
+      str
+    end
+  end
 end


### PR DESCRIPTION
At a minimum we should be able to read/write to JSON columns via a String. This solves for that.

https://github.com/crystal-lang/crystal-mysql/issues/64
https://github.com/amberframework/granite/issues/193