### PR TITLE
Fix connection to IPv6 hosts

### DIFF
--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -6,7 +6,7 @@ class MySql::Connection < DB::Connection
     @socket = uninitialized TCPSocket
 
     begin
-      raise "no host provided" unless host = context.uri.hostname
+      host = context.uri.hostname || raise "no host provided"
       port = context.uri.port || 3306
       username = context.uri.user
       password = context.uri.password

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -6,7 +6,7 @@ class MySql::Connection < DB::Connection
     @socket = uninitialized TCPSocket
 
     begin
-      host = context.uri.host.not_nil!
+      raise "no host provided" unless host = context.uri.hostname
       port = context.uri.port || 3306
       username = context.uri.user
       password = context.uri.password


### PR DESCRIPTION
An IPv6 host with brackets produces `Temporary failure in name resolution`.
A proper error message is also added if no host is defined.