### PR TITLE
Support MySQL 8

### DIFF
--- a/spec/driver_spec.cr
+++ b/spec/driver_spec.cr
@@ -12,18 +12,24 @@ describe Driver do
   it "should connect with credentials" do
     with_db do |db|
       db.scalar("SELECT DATABASE()").should be_nil
-      db.scalar("SELECT CURRENT_USER()").should match(/^root@/)
+      db.scalar("SELECT CURRENT_USER()").should match(/^#{database_user}@/)
 
       # ensure user is deleted
-      db.exec "GRANT USAGE ON *.* TO crystal_test IDENTIFIED BY 'secret'"
+      db.exec "SET GLOBAL validate_password.length = 6"
+      db.exec "SET GLOBAL validate_password.number_count = 0"
+      db.exec "SET GLOBAL validate_password.policy=LOW"
+      db.exec "DROP USER IF EXISTS crystal_test"
+      db.exec "CREATE USER crystal_test IDENTIFIED WITH mysql_native_password BY 'secret'"
+      db.exec "GRANT USAGE ON *.* TO crystal_test"
       db.exec "DROP USER crystal_test"
       db.exec "DROP DATABASE IF EXISTS crystal_mysql_test"
       db.exec "FLUSH PRIVILEGES"
 
       # create test db with user
       db.exec "CREATE DATABASE crystal_mysql_test"
-      db.exec "CREATE USER crystal_test IDENTIFIED BY 'secret'"
-      db.exec "GRANT ALL PRIVILEGES ON crystal_mysql_test.* TO crystal_test"
+      db.exec "DROP USER IF EXISTS 'crystal_test'@'#{database_host}'"
+      db.exec "CREATE USER 'crystal_test'@'#{database_host}' IDENTIFIED WITH mysql_native_password BY 'secret'"
+      db.exec "GRANT ALL PRIVILEGES ON crystal_mysql_test.* TO 'crystal_test'@'#{database_host}'"
       db.exec "FLUSH PRIVILEGES"
     end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,9 +4,17 @@ require "../src/mysql"
 include MySql
 
 def db_url(initial_db = nil)
-  "mysql://root@#{database_host}/#{initial_db}"
+  "mysql://#{database_user}:#{database_password}@#{database_host}/#{initial_db}"
 end
 
 def database_host
   ENV.fetch("DATABASE_HOST", "localhost")
+end
+
+def database_user
+  ENV.fetch("DATABASE_USER", "root")
+end
+
+def database_password
+  ENV.fetch("DATABASE_PASSWORD", "crystal_mysql_spec")
 end

--- a/src/mysql/packets.cr
+++ b/src/mysql/packets.cr
@@ -65,8 +65,6 @@ module MySql::Protocol
     def write(packet : MySql::WritePacket)
       caps = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA
 
-      caps |= CLIENT_PLUGIN_AUTH if @password
-
       caps |= CLIENT_CONNECT_WITH_DB if @initial_catalog
 
       packet.write_bytes caps, IO::ByteFormat::LittleEndian


### PR DESCRIPTION
Thankfully now GH has the _Draft Pull Request_ option, so no need to explicit it here 😉 

Some premises:

- I couldn't manage the driver to connect without password on MySQL 8, so I had to change the `spec_helper` to accept a password
- I changed the `driver_spec` to make the test more robust, with some `DROP IF EXISTS`
- As `secret` is considered a weak password on MySQL 8, I set the 3 globals to allow `secret` as a password for the user
- MySQL 8 does not allow creating a user on `GRANT` call, so I split in two, first `CREATE USER` then `GRANT`

The ~workaround~ fix for #62 is the removal on `src/mysql/packets`; not sure about the (likely) bad impact on MySQL 5 versions

Here on my machine, to run the tests, I created the user on DB

```sql
CREATE USER 'crystal_mysql_spec'@'localhost' IDENTIFIED WITH mysql_native_password BY 'crystal_mysql_spec';
GRANT ALL PRIVILEGES ON *.* TO 'crystal_mysql_spec'@'localhost' WITH GRANT OPTION;
FLUSH PRIVILEGES;
```

then

```bash
DATABASE_USER="crystal_mysql_spec" crystal spec
```

So yeah, here is what I could manage to do, any idea where we can go next? 😄 