### PR TITLE
Allow the time zone to be overridden via ENV var

### DIFF
--- a/src/mysql.cr
+++ b/src/mysql.cr
@@ -12,6 +12,10 @@ module MySql
 
   alias Any = DB::Any | Int16 | Int8 | Time::Span
 
+  def self.time_zone
+    ENV.has_key?("DB_TIME_ZONE") ? Time::Location.load(ENV["DB_TIME_ZONE"]) : Time::Location::UTC
+  end
+
   # :nodoc:
-  TIME_ZONE = Time::Location::UTC
+  TIME_ZONE = MySql.time_zone
 end


### PR DESCRIPTION
When living in a timezone that does not always match UTC, there needs to be an option to be able to set a location, as you will have difficulties during daylight saving or a season that changes the time diff.

Seems like an ENV var is the best way to achieve this and preserve current behaviour if one hasn't been supplied.

Cheers