### PR TITLE
CI and spec maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        crystal: [1.0.0, latest, nightly]
+        crystal: [1.3.0, latest, nightly]
         mysql_docker_image: ["mysql:5.6", "mysql:5.7"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/spec/db_spec.cr
+++ b/spec/db_spec.cr
@@ -48,8 +48,7 @@ DB::DriverSpecs(MySql::Any).run do |ctx|
 
   DB.open db_url do |db|
     # needs to check version, microsecond support >= 5.7
-    dbversion = SemanticVersion.parse(db.scalar("SELECT VERSION();").as(String))
-    if dbversion >= SemanticVersion.new(5, 7, 0)
+    if mysql_version(db) >= SemanticVersion.new(5, 7, 0)
       sample_value Time.utc(2016, 2, 15, 10, 15, 30, nanosecond: 543_000_000), "datetime(3)", "TIMESTAMP '2016-02-15 10:15:30.543'"
       sample_value Time.utc(2016, 2, 15, 10, 15, 30, nanosecond: 543_012_000), "datetime(6)", "TIMESTAMP '2016-02-15 10:15:30.543012'"
       sample_value Time.utc(2016, 2, 15, 10, 15, 30, nanosecond: 543_000_000), "timestamp(3)", "TIMESTAMP '2016-02-15 10:15:30.543'"

--- a/spec/pool_spec.cr
+++ b/spec/pool_spec.cr
@@ -14,7 +14,7 @@ describe DB::Pool do
         spawn do
           (1..max_n).each do |n|
             db.exec "insert into numbers (n, fiber) values (?, ?)", n, f
-            sleep 0.01
+            sleep 0.01.seconds
           end
           channel.send nil
         end
@@ -46,7 +46,7 @@ describe DB::Pool do
         spawn do
           cnn = db.checkout
           max_open_connections.max(db.pool.stats.open_connections)
-          sleep 0.01
+          sleep 0.01.seconds
           cnn.release
           channel.send nil
         end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "../src/mysql"
+require "semantic_version"
 
 include MySql
 
@@ -22,4 +23,9 @@ ensure
   DB.open db_url do |db|
     db.exec "DROP DATABASE IF EXISTS crystal_mysql_test"
   end
+end
+
+def mysql_version(db) : SemanticVersion
+  # some docker images might report 5.7.30-0ubuntu0.18.04.1, so we split in "-"
+  SemanticVersion.parse(db.scalar("SELECT VERSION();").as(String).split("-").first)
 end


### PR DESCRIPTION
- Bumping minimal crystal in ci to 1.3 due to openssl available in ci and incompatibilities with older crystal versions. The shard itself should still work with pre 1.3 crystal versions
- Fix some deprecations and refactors in specs