### PR TITLE
Add ssl support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        crystal: [1.3.0, latest, nightly]
+        crystal: [1.9.0, latest, nightly]
         mysql_version: ["5.7"]
         database_host: ["default", "/tmp/mysql.sock"]
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Query string takes precedence because it's more explicit.
 
 #### Secure connections (SSL/TLS)
 
-By default a tcp conenction will stablish a secure connection, whether a unix socket will not.
+By default a tcp connection will establish a secure connection, whether a unix socket will not.
 
 You can tweak this default behaviour and require further validation of certificates using `ssl-mode` and the following query strings.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ Query string takes precedence because it's more explicit.
 - `mysql://localhost:3306?database=mydb`
 - `mysql:///path/to/other.sock?database=mydb`
 
+#### Secure connections (SSL/TLS)
+
+By default a tcp conenction will stablish a secure connection, whether a unix socket will not.
+
+You can tweak this default behaviour and require further validation of certificates using `ssl-mode` and the following query strings.
+
+- `ssl-mode`: Either `disabled`, `preferred` (default), `required`, `verify_ca`, `verify_identity`.
+- `ssl-key`: Path to the client key.
+- `ssl-cert`: Path to the client certificate.
+- `ssl-ca`: Path to the CA certificate.
+
 #### Other query params
 
 - `encoding`: The collation & charset (character set) to use during the connection.

--- a/spec/connection_options_spec.cr
+++ b/spec/connection_options_spec.cr
@@ -12,113 +12,180 @@ private def socket(path)
   URI.new("unix", nil, nil, path)
 end
 
+private def ssl_from_params(params)
+  Connection::SSLOptions.from_params(URI::Params.parse(params))
+end
+
+SSL_OPTION_PREFERRED = Connection::SSLOptions.new(mode: :preferred, key: nil, cert: nil, ca: nil)
+
 describe Connection::Options do
   describe ".from_uri" do
     it "parses mysql://user@host/db" do
       from_uri("mysql://root@localhost/test").should eq(
-        MySql::Connection::Options.new(
+        Connection::Options.new(
           transport: tcp("localhost", 3306),
           username: "root",
           password: nil,
           initial_catalog: "test",
-          charset: Collations.default_collation
+          charset: Collations.default_collation,
+          ssl_options: SSL_OPTION_PREFERRED
         )
       )
     end
 
     it "parses mysql://host" do
       from_uri("mysql://localhost").should eq(
-        MySql::Connection::Options.new(
+        Connection::Options.new(
           transport: tcp("localhost", 3306),
           username: nil,
           password: nil,
           initial_catalog: nil,
-          charset: Collations.default_collation
+          charset: Collations.default_collation,
+          ssl_options: SSL_OPTION_PREFERRED
         )
       )
     end
 
     it "parses mysql://host:port" do
       from_uri("mysql://localhost:1234").should eq(
-        MySql::Connection::Options.new(
+        Connection::Options.new(
           transport: tcp("localhost", 1234),
           username: nil,
           password: nil,
           initial_catalog: nil,
-          charset: Collations.default_collation
+          charset: Collations.default_collation,
+          ssl_options: SSL_OPTION_PREFERRED
         )
       )
     end
 
     it "parses ?encoding=..." do
       from_uri("mysql://localhost:1234?encoding=utf8mb4_unicode_520_ci").should eq(
-        MySql::Connection::Options.new(
+        Connection::Options.new(
           transport: tcp("localhost", 1234),
           username: nil,
           password: nil,
           initial_catalog: nil,
-          charset: "utf8mb4_unicode_520_ci"
+          charset: "utf8mb4_unicode_520_ci",
+          ssl_options: SSL_OPTION_PREFERRED
         )
       )
     end
 
     it "parses mysql://user@host?database=db" do
       from_uri("mysql://root@localhost?database=test").should eq(
-        MySql::Connection::Options.new(
+        Connection::Options.new(
           transport: tcp("localhost", 3306),
           username: "root",
           password: nil,
           initial_catalog: "test",
-          charset: Collations.default_collation
+          charset: Collations.default_collation,
+          ssl_options: SSL_OPTION_PREFERRED
         )
       )
     end
 
     it "parses mysql:///path/to/socket" do
       from_uri("mysql:///path/to/socket").should eq(
-        MySql::Connection::Options.new(
+        Connection::Options.new(
           transport: socket("/path/to/socket"),
           username: nil,
           password: nil,
           initial_catalog: nil,
-          charset: Collations.default_collation
+          charset: Collations.default_collation,
+          ssl_options: SSL_OPTION_PREFERRED
         )
       )
     end
 
     it "parses mysql:///path/to/socket?database=test" do
       from_uri("mysql:///path/to/socket?database=test").should eq(
-        MySql::Connection::Options.new(
+        Connection::Options.new(
           transport: socket("/path/to/socket"),
           username: nil,
           password: nil,
           initial_catalog: "test",
-          charset: Collations.default_collation
+          charset: Collations.default_collation,
+          ssl_options: SSL_OPTION_PREFERRED
         )
       )
     end
 
     it "parses mysql:///path/to/socket?encoding=utf8mb4_unicode_520_ci" do
       from_uri("mysql:///path/to/socket?encoding=utf8mb4_unicode_520_ci").should eq(
-        MySql::Connection::Options.new(
+        Connection::Options.new(
           transport: socket("/path/to/socket"),
           username: nil,
           password: nil,
           initial_catalog: nil,
-          charset: "utf8mb4_unicode_520_ci"
+          charset: "utf8mb4_unicode_520_ci",
+          ssl_options: SSL_OPTION_PREFERRED
         )
       )
     end
 
     it "parses mysql://user:pass@/path/to/socket?database=test" do
       from_uri("mysql://root:password@/path/to/socket?database=test").should eq(
-        MySql::Connection::Options.new(
+        Connection::Options.new(
           transport: socket("/path/to/socket"),
           username: "root",
           password: "password",
           initial_catalog: "test",
-          charset: Collations.default_collation
+          charset: Collations.default_collation,
+          ssl_options: SSL_OPTION_PREFERRED
         )
+      )
+    end
+  end
+end
+
+describe Connection::SSLOptions do
+  describe ".from_params" do
+    it "default is ssl-mode=preferred" do
+      ssl_from_params("").mode.should eq(Connection::SSLMode::Preferred)
+    end
+
+    it "parses ssl-mode=preferred" do
+      ssl_from_params("ssl-mode=preferred").mode.should eq(Connection::SSLMode::Preferred)
+      ssl_from_params("ssl-mode=Preferred").mode.should eq(Connection::SSLMode::Preferred)
+      ssl_from_params("ssl-mode=PREFERRED").mode.should eq(Connection::SSLMode::Preferred)
+    end
+
+    it "parses ssl-mode=disabled" do
+      ssl_from_params("ssl-mode=disabled").mode.should eq(Connection::SSLMode::Disabled)
+      ssl_from_params("ssl-mode=Disabled").mode.should eq(Connection::SSLMode::Disabled)
+      ssl_from_params("ssl-mode=DISABLED").mode.should eq(Connection::SSLMode::Disabled)
+    end
+
+    it "parses ssl-mode=verifyca" do
+      ssl_from_params("ssl-mode=verifyca").mode.should eq(Connection::SSLMode::VerifyCA)
+      ssl_from_params("ssl-mode=verify-ca").mode.should eq(Connection::SSLMode::VerifyCA)
+      ssl_from_params("ssl-mode=verify_ca").mode.should eq(Connection::SSLMode::VerifyCA)
+      ssl_from_params("ssl-mode=VERIFY_CA").mode.should eq(Connection::SSLMode::VerifyCA)
+    end
+
+    it "parses ssl-mode=verifyidentity" do
+      ssl_from_params("ssl-mode=verifyidentity").mode.should eq(Connection::SSLMode::VerifyIdentity)
+      ssl_from_params("ssl-mode=verify-identity").mode.should eq(Connection::SSLMode::VerifyIdentity)
+      ssl_from_params("ssl-mode=verify_identity").mode.should eq(Connection::SSLMode::VerifyIdentity)
+      ssl_from_params("ssl-mode=VERIFY_IDENTITY").mode.should eq(Connection::SSLMode::VerifyIdentity)
+    end
+
+    it "parses ssl-key, ssl-cert, ssl-ca" do
+      ssl_from_params("ssl-key=path/to/key.pem&ssl-cert=path/to/cert.pem&ssl-ca=path/to/ca.pem").should eq(
+        Connection::SSLOptions.new(mode: Connection::SSLMode::Preferred,
+          key: Path["path/to/key.pem"],
+          cert: Path["path/to/cert.pem"],
+          ca: Path["path/to/ca.pem"])
+      )
+    end
+
+    it "missing ssl-key, ssl-cert, ssl-ca as nil" do
+      ssl_from_params("").should eq(
+        Connection::SSLOptions.new(mode: Connection::SSLMode::Preferred,
+          key: nil,
+          cert: nil,
+          ca: nil)
       )
     end
   end

--- a/spec/connection_options_spec.cr
+++ b/spec/connection_options_spec.cr
@@ -174,9 +174,9 @@ describe Connection::SSLOptions do
     it "parses ssl-key, ssl-cert, ssl-ca" do
       ssl_from_params("ssl-key=path/to/key.pem&ssl-cert=path/to/cert.pem&ssl-ca=path/to/ca.pem").should eq(
         Connection::SSLOptions.new(mode: Connection::SSLMode::Preferred,
-          key: Path["path/to/key.pem"],
-          cert: Path["path/to/cert.pem"],
-          ca: Path["path/to/ca.pem"])
+          key: Path["path/to/key.pem"].expand(home: true),
+          cert: Path["path/to/cert.pem"].expand(home: true),
+          ca: Path["path/to/ca.pem"].expand(home: true))
       )
     end
 

--- a/spec/connection_options_spec.cr
+++ b/spec/connection_options_spec.cr
@@ -16,7 +16,7 @@ private def ssl_from_params(params)
   Connection::SSLOptions.from_params(URI::Params.parse(params))
 end
 
-SSL_OPTION_PREFERRED = Connection::SSLOptions.new(mode: :preferred, key: nil, cert: nil, ca: nil)
+SSL_OPTION_PREFERRED = Connection::SSLOptions.new(mode: :preferred)
 
 describe Connection::Options do
   describe ".from_uri" do

--- a/spec/driver_spec.cr
+++ b/spec/driver_spec.cr
@@ -69,6 +69,18 @@ describe Driver do
     end
   end
 
+  it "should be able to connect without ssl" do
+    with_db nil, "ssl-mode=disabled" do |db|
+      db.scalar("SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'Ssl_cipher'").should eq("")
+    end
+  end
+
+  it "should be able to connect with ssl" do
+    with_db nil, "ssl-mode=required" do |db|
+      db.scalar("SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'Ssl_cipher'").should_not eq("")
+    end
+  end
+
   it "create and drop test database" do
     sql = "SELECT count(*) FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'crystal_mysql_test'"
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -8,7 +8,7 @@ def db_url(initial_db = nil)
   if initial_db
     "mysql://root@#{database_host}?database=#{initial_db}"
   else
-    "mysql://root@#{database_host}"
+    "mysql://root@#{database_host}?"
   end
 end
 

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -20,9 +20,9 @@ class MySql::Connection < DB::Connection
 
       # NOTE: Passing paths prefixed with ~/ or ./ seems to not work with OpenSSL
       # we we expand the provided path.
-      key = (params["ssl-key"]?).try { |v| Path[File.expand_path(v, home: true)] }
-      cert = (params["ssl-cert"]?).try { |v| Path[File.expand_path(v, home: true)] }
-      ca = (params["ssl-ca"]?).try { |v| Path[File.expand_path(v, home: true)] }
+      key = (params["ssl-key"]?).try { |v| Path[v].expand(home: true) }
+      cert = (params["ssl-cert"]?).try { |v| Path[v].expand(home: true) }
+      ca = (params["ssl-ca"]?).try { |v| Path[v].expand(home: true) }
 
       SSLOptions.new(mode: mode, key: key, cert: cert, ca: ca)
     end

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -1,12 +1,69 @@
 require "socket"
+require "openssl"
 
 class MySql::Connection < DB::Connection
+  enum SSLMode
+    Disabled
+    Preferred
+    Required
+    VerifyCA
+    VerifyIdentity
+  end
+  record SSLOptions, mode : SSLMode, key : Path?, cert : Path?, ca : Path? do
+    def self.from_params(params : URI::Params)
+      mode =
+        case (params["ssl-mode"]?).try &.downcase
+        when nil
+          SSLMode::Preferred
+        when "preferred"
+          SSLMode::Preferred
+        when "disabled"
+          SSLMode::Disabled
+        when "required"
+          SSLMode::Required
+        when "verifyca", "verify-ca", "verify_ca"
+          SSLMode::VerifyCA
+        when "verifyidentity", "verify-identity", "verify_identity"
+          SSLMode::VerifyIdentity
+        else
+          raise ArgumentError.new(%(invalid "#{params["ssl-mode"]}" value for ssl-mode))
+        end
+
+      # NOTE: Passing paths prefixed with ~/ or ./ seems to not work with OpenSSL
+      # we we expand the provided path.
+      key = (params["ssl-key"]?).try { |v| Path[File.expand_path(v, home: true)] }
+      cert = (params["ssl-cert"]?).try { |v| Path[File.expand_path(v, home: true)] }
+      ca = (params["ssl-ca"]?).try { |v| Path[File.expand_path(v, home: true)] }
+
+      SSLOptions.new(mode: mode, key: key, cert: cert, ca: ca)
+    end
+
+    def build_context : OpenSSL::SSL::Context::Client
+      ctx = OpenSSL::SSL::Context::Client.new
+
+      ctx.verify_mode =
+        case mode
+        when SSLMode::VerifyCA, SSLMode::VerifyIdentity
+          OpenSSL::SSL::VerifyMode::PEER
+        else
+          OpenSSL::SSL::VerifyMode::NONE
+        end
+
+      ctx.certificate_chain = cert.to_s if cert = @cert
+      ctx.private_key = key.to_s if key = @key
+      ctx.ca_certificates = ca.to_s if ca = @ca
+
+      ctx
+    end
+  end
+
   record Options,
     transport : URI,
     username : String?,
     password : String?,
     initial_catalog : String?,
-    charset : String do
+    charset : String,
+    ssl_options : SSLOptions do
     def self.from_uri(uri : URI) : Options
       params = uri.query_params
       initial_catalog = params["database"]?
@@ -32,23 +89,26 @@ class MySql::Connection < DB::Connection
       Options.new(
         transport: transport,
         username: username, password: password,
-        initial_catalog: initial_catalog, charset: charset)
+        initial_catalog: initial_catalog, charset: charset,
+        ssl_options: SSLOptions.from_params(params)
+      )
     end
   end
 
   def initialize(options : ::DB::Connection::Options, mysql_options : ::MySql::Connection::Options)
     super(options)
-    @socket = uninitialized UNIXSocket | TCPSocket
+    @socket = uninitialized UNIXSocket | TCPSocket | OpenSSL::SSL::Socket::Client
 
     begin
       charset_id = Collations.id_for_collation(mysql_options.charset).to_u8
 
       transport = mysql_options.transport
+      hostname = nil
       @socket =
         case transport.scheme
         when "tcp"
-          host = transport.host || raise "Missing host in transport #{transport}"
-          TCPSocket.new(host, transport.port)
+          hostname = transport.host || raise "Missing host in transport #{transport}"
+          TCPSocket.new(hostname, transport.port)
         when "unix"
           UNIXSocket.new(transport.path)
         else
@@ -57,8 +117,25 @@ class MySql::Connection < DB::Connection
 
       handshake = read_packet(Protocol::HandshakeV10)
 
-      write_packet(1) do |packet|
-        Protocol::HandshakeResponse41.new(mysql_options.username, mysql_options.password, mysql_options.initial_catalog, handshake.auth_plugin_data, charset_id).write(packet)
+      handshake_response = Protocol::HandshakeResponse41.new(mysql_options.username, mysql_options.password, mysql_options.initial_catalog, handshake.auth_plugin_data, charset_id)
+      seq = 1
+
+      if mysql_options.ssl_options.mode != SSLMode::Disabled &&
+         # socket connection will not use ssl for preferred
+         !(transport.scheme == "unix" && mysql_options.ssl_options.mode == SSLMode::Preferred)
+        write_packet(seq) do |packet|
+          handshake_response.write_ssl_request(packet)
+        end
+        seq += 1
+        ctx = mysql_options.ssl_options.build_context
+        @socket = OpenSSL::SSL::Socket::Client.new(@socket, context: ctx, sync_close: true, hostname: hostname)
+        # NOTE: If ssl_options.mode is Preferred we should fallback to non-ssl socket if the ssl setup failed
+        # if we do so, we should warn at least. Making Preferred behave as Required is a safer option
+        # so the user would need to explicitly choose Disabled to avoid the ssl setup.
+      end
+
+      write_packet(seq) do |packet|
+        handshake_response.write(packet)
       end
 
       read_ok_or_err do |packet, status|

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -12,21 +12,10 @@ class MySql::Connection < DB::Connection
   record SSLOptions, mode : SSLMode, key : Path? = nil, cert : Path? = nil, ca : Path? = nil do
     def self.from_params(params : URI::Params)
       mode =
-        case (params["ssl-mode"]?).try &.downcase
-        when nil
-          SSLMode::Preferred
-        when "preferred"
-          SSLMode::Preferred
-        when "disabled"
-          SSLMode::Disabled
-        when "required"
-          SSLMode::Required
-        when "verifyca", "verify-ca", "verify_ca"
-          SSLMode::VerifyCA
-        when "verifyidentity", "verify-identity", "verify_identity"
-          SSLMode::VerifyIdentity
+        if mode_param = params["ssl-mode"]?
+          SSLMode.parse(mode_param)
         else
-          raise ArgumentError.new(%(invalid "#{params["ssl-mode"]}" value for ssl-mode))
+          SSLMode::Preferred
         end
 
       # NOTE: Passing paths prefixed with ~/ or ./ seems to not work with OpenSSL

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -9,7 +9,7 @@ class MySql::Connection < DB::Connection
     VerifyCA
     VerifyIdentity
   end
-  record SSLOptions, mode : SSLMode, key : Path?, cert : Path?, ca : Path? do
+  record SSLOptions, mode : SSLMode, key : Path? = nil, cert : Path? = nil, ca : Path? = nil do
     def self.from_params(params : URI::Params)
       mode =
         case (params["ssl-mode"]?).try &.downcase


### PR DESCRIPTION
Going forward, by default a tcp conenction will stablish a secure connection, whether a unix socket will not.

This PR also introduce a couple of more query strings/connection strings to further secure the connection.

- `ssl-mode`: Either `disabled`, `preferred` (default), `required`, `verify_ca`, `verify_identity`.
- `ssl-key`: Path to the client key.
- `ssl-cert`: Path to the client certificate.
- `ssl-ca`: Path to the CA certificate.

Fixes #14 