### PR TITLE
Handle err packet gracefully

### DIFF
--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -2,7 +2,7 @@ require "socket"
 require "openssl"
 
 class MySql::Connection < DB::Connection
-  class Error < Exception; end
+  class PacketError < Exception; end
 
   enum SSLMode
     Disabled
@@ -217,7 +217,7 @@ class MySql::Connection < DB::Connection
     when 1053, 1152, 1927, 2006, 2013
       raise DB::ConnectionLost.new(self, Exception.new(message))
     else
-      raise Error.new(message)
+      raise PacketError.new(message)
     end
   end
 

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -206,6 +206,13 @@ class MySql::Connection < DB::Connection
     packet.read_byte_array(6)
     message = packet.read_string
 
+    # https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+    # https://dev.mysql.com/doc/mysql-errors/8.0/en/client-error-reference.html
+    # Error 1053: Server shutdown in progress
+    # Error 1152: Aborted connection to db user
+    # Error 1927: Connection was killed
+    # Error 2006: MySQL server has gone away
+    # Error 2013: Lost connection to MySQL server during query
     case error_code
     when 1053, 1152, 1927, 2006, 2013
       raise DB::ConnectionLost.new(self, Exception.new(message))

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -2,6 +2,8 @@ require "socket"
 require "openssl"
 
 class MySql::Connection < DB::Connection
+  class Error < Exception; end
+
   enum SSLMode
     Disabled
     Preferred
@@ -200,8 +202,16 @@ class MySql::Connection < DB::Connection
 
   # :nodoc:
   def handle_err_packet(packet)
-    8.times { packet.read_byte! }
-    raise packet.read_string
+    error_code = packet.read_fixed_int(2)
+    packet.read_byte_array(6)
+    message = packet.read_string
+
+    case error_code
+    when 1053, 1152, 1927, 2006, 2013
+      raise DB::ConnectionLost.new(self, Exception.new(message))
+    else
+      raise Error.new(message)
+    end
   end
 
   # :nodoc:

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -215,7 +215,7 @@ class MySql::Connection < DB::Connection
     # Error 2013: Lost connection to MySQL server during query
     case error_code
     when 1053, 1152, 1927, 2006, 2013
-      raise DB::ConnectionLost.new(self, Exception.new(message))
+      raise DB::ConnectionLost.new(self, PacketError.new(message))
     else
       raise PacketError.new(message)
     end


### PR DESCRIPTION
This PR fixes a bug where packet errors such as "Connection was killed" were raised using the generic `Exception` class, and weren't handled correctly. The client was then unable to reconnect to the MySQL instance because the connection pool didn't know it was a connection error. The reconnect logic is handled correctly when `DB::ConnectionLost` is raised, so I modified the `err_packet` handler to catch specific network disconnection events, and raise that error.

It also adds a `PacketError` Exception handler to the `MySql::Connection` class, for the remaining errors (there's so many 😩). This way we can rescue `MySql::Connection:PacketError` and gracefully handle those.

Finally, I've added comments and references to the specific error codes, but the list is unbelievably long, I don't think it would be wise to try and keep-up 😅.

As a side note, I saw in #110 some effort was started to add proper Exceptions, I believe that thread should be resurrected in order to make this driver more reliable. I'm happy to take a stab at it but I can't guarantee a completion date due to extremely limited availability (kids).