### PR TITLE
Add multi-auth plugin support

### DIFF
--- a/docker-compose.auth-test.yml
+++ b/docker-compose.auth-test.yml
@@ -1,0 +1,49 @@
+# Usage:
+#   docker-compose -f docker-compose.auth-test.yml up -d
+#   docker-compose -f docker-compose.auth-test.yml down -v
+
+version: '2.0'
+
+services:
+  mysql57:
+    image: biarms/mysql:5.7
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    ports:
+      - "13306:3306"
+
+  mysql80:
+    image: mysql:8.0
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    ports:
+      - "13307:3306"
+    volumes:
+      - ./docker/auth-test/mysql80-init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  mysql80_native:
+    image: mysql:8.0
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    command:
+      - --default-authentication-plugin=mysql_native_password
+    ports:
+      - "13308:3306"
+    volumes:
+      - ./docker/auth-test/mysql80n-init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  mysql90:
+    image: mysql:9.0
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    ports:
+      - "13309:3306"
+    volumes:
+      - ./docker/auth-test/mysql90-init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  mariadb:
+    image: mariadb:11
+    environment:
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes'
+    ports:
+      - "13310:3306"

--- a/docker-compose.auth-test.yml
+++ b/docker-compose.auth-test.yml
@@ -1,8 +1,6 @@
 # Usage:
-#   docker-compose -f docker-compose.auth-test.yml up -d
-#   docker-compose -f docker-compose.auth-test.yml down -v
-
-version: '2.0'
+#   docker compose -f docker-compose.auth-test.yml up -d
+#   docker compose -f docker-compose.auth-test.yml down -v
 
 services:
   mysql57:

--- a/docker/auth-test/mysql80-init.sql
+++ b/docker/auth-test/mysql80-init.sql
@@ -1,0 +1,14 @@
+-- Init script for mysql:8.0 (default auth: caching_sha2_password)
+-- Creates test users with various authentication plugins.
+
+CREATE USER 'native_user'@'%' IDENTIFIED WITH mysql_native_password BY 'native_pass';
+CREATE USER 'csha2_user'@'%' IDENTIFIED WITH caching_sha2_password BY 'csha2_pass';
+CREATE USER 'sha256_user'@'%' IDENTIFIED WITH sha256_password BY 'sha256_pass';
+CREATE USER 'nopass_user'@'%' IDENTIFIED WITH mysql_native_password;
+
+GRANT ALL PRIVILEGES ON *.* TO 'native_user'@'%';
+GRANT ALL PRIVILEGES ON *.* TO 'csha2_user'@'%';
+GRANT ALL PRIVILEGES ON *.* TO 'sha256_user'@'%';
+GRANT ALL PRIVILEGES ON *.* TO 'nopass_user'@'%';
+
+FLUSH PRIVILEGES;

--- a/docker/auth-test/mysql80n-init.sql
+++ b/docker/auth-test/mysql80n-init.sql
@@ -1,0 +1,10 @@
+-- Init script for mysql:8.0 with --default-authentication-plugin=mysql_native_password
+-- Creates test users to trigger auth switch scenarios.
+
+CREATE USER 'csha2_user'@'%' IDENTIFIED WITH caching_sha2_password BY 'csha2_pass';
+CREATE USER 'native_user'@'%' IDENTIFIED WITH mysql_native_password BY 'native_pass';
+
+GRANT ALL PRIVILEGES ON *.* TO 'csha2_user'@'%';
+GRANT ALL PRIVILEGES ON *.* TO 'native_user'@'%';
+
+FLUSH PRIVILEGES;

--- a/docker/auth-test/mysql90-init.sql
+++ b/docker/auth-test/mysql90-init.sql
@@ -1,0 +1,8 @@
+-- Init script for mysql:9.0 (caching_sha2_password only, native removed)
+-- Creates test user with default auth (caching_sha2_password).
+
+CREATE USER 'csha2_user'@'%' IDENTIFIED BY 'csha2_pass';
+
+GRANT ALL PRIVILEGES ON *.* TO 'csha2_user'@'%';
+
+FLUSH PRIVILEGES;

--- a/spec/auth_spec.cr
+++ b/spec/auth_spec.cr
@@ -1,0 +1,109 @@
+require "./spec_helper"
+
+# Reference vectors computed independently using openssl + python XOR.
+# Source inputs are documented per-test; re-derivable as:
+#   printf '%s' "<password>" | openssl dgst -sha1 -binary > stage1
+#   openssl dgst -sha1 -binary < stage1 > stage2
+#   { printf '%s' "<scramble>"; cat stage2; } | openssl dgst -sha1 -binary > intermediate
+#   result = stage1 XOR intermediate
+describe MySql::Auth do
+  describe ".native_password" do
+    it "matches reference vector for password='secret', scramble='12345678901234567890'" do
+      scramble = "12345678901234567890".to_slice
+      result = MySql::Auth.native_password("secret", scramble)
+      result.hexstring.should eq("0f8b9033e0897c0a8338ebe3dea9010dda47ab56")
+    end
+
+    it "matches reference vector for password='pass', scramble='abcdefghij1234567890'" do
+      scramble = "abcdefghij1234567890".to_slice
+      result = MySql::Auth.native_password("pass", scramble)
+      result.hexstring.should eq("97406e93d6b93db22d075b4f0f82e72168da5583")
+    end
+
+    it "produces 20-byte output" do
+      result = MySql::Auth.native_password("x", "12345678901234567890".to_slice)
+      result.size.should eq(20)
+    end
+  end
+
+  describe ".caching_sha2_password" do
+    it "matches reference vector for password='secret', scramble='12345678901234567890'" do
+      scramble = "12345678901234567890".to_slice
+      result = MySql::Auth.caching_sha2_password("secret", scramble)
+      result.hexstring.should eq("51ecd6dedbd34d5445c0a190d4f51acf0d23b94db66c91f3f789faa9193751cd")
+    end
+
+    it "produces 32-byte output" do
+      result = MySql::Auth.caching_sha2_password("x", "12345678901234567890".to_slice)
+      result.size.should eq(32)
+    end
+  end
+
+  describe ".clear_password" do
+    it "appends null terminator" do
+      MySql::Auth.clear_password("foo").should eq(Bytes[0x66, 0x6f, 0x6f, 0x00])
+    end
+
+    it "handles empty password" do
+      MySql::Auth.clear_password("").should eq(Bytes[0x00])
+    end
+  end
+
+  describe ".xor_password_scramble" do
+    it "XORs password with cycled scramble and null-terminates with XOR" do
+      result = MySql::Auth.xor_password_scramble("foo", "123456789012345678901234".to_slice)
+      result.hexstring.should eq("575d5c34")
+    end
+
+    it "cycles scramble when password is longer" do
+      result = MySql::Auth.xor_password_scramble("abcdefghijklmnop12345", "12345678901234567890".to_slice)
+      result.hexstring.should eq("5050505050505050505a5a5e5e5a5a46060a0a040432")
+    end
+  end
+
+  describe ".compute_auth_response" do
+    it "returns empty bytes when password is nil" do
+      scramble = "12345678901234567890".to_slice
+      MySql::Auth.compute_auth_response("mysql_native_password", nil, scramble).should eq(Bytes.empty)
+    end
+
+    it "returns empty bytes when password is empty string" do
+      scramble = "12345678901234567890".to_slice
+      MySql::Auth.compute_auth_response("mysql_native_password", "", scramble).should eq(Bytes.empty)
+    end
+
+    it "dispatches to native_password for mysql_native_password" do
+      scramble = "12345678901234567890".to_slice
+      result = MySql::Auth.compute_auth_response("mysql_native_password", "secret", scramble)
+      result.hexstring.should eq("0f8b9033e0897c0a8338ebe3dea9010dda47ab56")
+    end
+
+    it "dispatches to caching_sha2_password for caching_sha2_password" do
+      scramble = "12345678901234567890".to_slice
+      result = MySql::Auth.compute_auth_response("caching_sha2_password", "secret", scramble)
+      result.hexstring.should eq("51ecd6dedbd34d5445c0a190d4f51acf0d23b94db66c91f3f789faa9193751cd")
+    end
+
+    it "returns [0x01] for sha256_password without TLS (key request)" do
+      scramble = "12345678901234567890".to_slice
+      MySql::Auth.compute_auth_response("sha256_password", "secret", scramble, ssl_established: false).should eq(Bytes[0x01])
+    end
+
+    it "returns plaintext+null for sha256_password over TLS" do
+      scramble = "12345678901234567890".to_slice
+      MySql::Auth.compute_auth_response("sha256_password", "foo", scramble, ssl_established: true).should eq(Bytes[0x66, 0x6f, 0x6f, 0x00])
+    end
+
+    it "dispatches to clear_password for mysql_clear_password" do
+      scramble = "12345678901234567890".to_slice
+      MySql::Auth.compute_auth_response("mysql_clear_password", "foo", scramble).should eq(Bytes[0x66, 0x6f, 0x6f, 0x00])
+    end
+
+    it "raises on unsupported plugin" do
+      scramble = "12345678901234567890".to_slice
+      expect_raises(MySql::Connection::PacketError, /Unsupported auth plugin/) do
+        MySql::Auth.compute_auth_response("nonexistent_plugin", "x", scramble)
+      end
+    end
+  end
+end

--- a/spec/manual/auth_caching_sha2_test.cr
+++ b/spec/manual/auth_caching_sha2_test.cr
@@ -1,0 +1,26 @@
+# Target: mysql80 (port 13307), mysql90 (port 13309)
+# Run:    crystal run spec/manual/auth_caching_sha2_test.cr
+#
+# Tests caching_sha2_password authentication.
+# Expected to FAIL with current code.
+
+require "../../src/mysql"
+
+tests = [
+  {"mysql://root@localhost:13307", "mysql80 root no password (csha2 default)"},
+  {"mysql://csha2_user:csha2_pass@localhost:13307", "csha2_user with password"},
+  {"mysql://nopass_user@localhost:13307", "nopass_user empty password"},
+  {"mysql://root@localhost:13309", "mysql90 root no password"},
+  {"mysql://csha2_user:csha2_pass@localhost:13309", "mysql90 csha2_user"},
+]
+
+tests.each do |url, label|
+  begin
+    DB.open(url) do |db|
+      user = db.scalar("SELECT CURRENT_USER()").as(String)
+      puts "PASS: #{label} (user=#{user})"
+    end
+  rescue ex
+    puts "FAIL: #{label} — #{ex.message}"
+  end
+end

--- a/spec/manual/auth_caching_sha2_test.cr
+++ b/spec/manual/auth_caching_sha2_test.cr
@@ -1,26 +1,23 @@
 # Target: mysql80 (port 13307), mysql90 (port 13309)
-# Run:    crystal run spec/manual/auth_caching_sha2_test.cr
+# Run:    crystal spec spec/manual/auth_caching_sha2_test.cr
 #
 # Tests caching_sha2_password authentication.
-# Expected to FAIL with current code.
 
+require "spec"
 require "../../src/mysql"
 
-tests = [
-  {"mysql://root@localhost:13307", "mysql80 root no password (csha2 default)"},
-  {"mysql://csha2_user:csha2_pass@localhost:13307", "csha2_user with password"},
-  {"mysql://nopass_user@localhost:13307", "nopass_user empty password"},
-  {"mysql://root@localhost:13309", "mysql90 root no password"},
-  {"mysql://csha2_user:csha2_pass@localhost:13309", "mysql90 csha2_user"},
-]
-
-tests.each do |url, label|
-  begin
-    DB.open(url) do |db|
-      user = db.scalar("SELECT CURRENT_USER()").as(String)
-      puts "PASS: #{label} (user=#{user})"
+describe "caching_sha2_password authentication" do
+  [
+    {"mysql://root@localhost:13307", "mysql80 root no password (csha2 default)"},
+    {"mysql://csha2_user:csha2_pass@localhost:13307", "csha2_user with password"},
+    {"mysql://nopass_user@localhost:13307", "nopass_user empty password"},
+    {"mysql://root@localhost:13309", "mysql90 root no password"},
+    {"mysql://csha2_user:csha2_pass@localhost:13309", "mysql90 csha2_user"},
+  ].each do |(url, label)|
+    it label do
+      DB.open(url) do |db|
+        db.scalar("SELECT CURRENT_USER()").as(String).should_not be_empty
+      end
     end
-  rescue ex
-    puts "FAIL: #{label} — #{ex.message}"
   end
 end

--- a/spec/manual/auth_clear_password_test.cr
+++ b/spec/manual/auth_clear_password_test.cr
@@ -1,0 +1,22 @@
+# Target: mysql80 (port 13307)
+# Run:    crystal run spec/manual/auth_clear_password_test.cr
+#
+# mysql_clear_password requires server-side plugin (PAM/LDAP) that requests it.
+# Our docker setup doesn't trigger this path, so this is a baseline connectivity test.
+
+require "../../src/mysql"
+
+tests = [
+  {"mysql://root@localhost:13307", "baseline connectivity"},
+]
+
+tests.each do |url, label|
+  begin
+    DB.open(url) do |db|
+      user = db.scalar("SELECT CURRENT_USER()").as(String)
+      puts "PASS: #{label} (user=#{user})"
+    end
+  rescue ex
+    puts "FAIL: #{label} — #{ex.message}"
+  end
+end

--- a/spec/manual/auth_clear_password_test.cr
+++ b/spec/manual/auth_clear_password_test.cr
@@ -1,22 +1,20 @@
 # Target: mysql80 (port 13307)
-# Run:    crystal run spec/manual/auth_clear_password_test.cr
+# Run:    crystal spec spec/manual/auth_clear_password_test.cr
 #
 # mysql_clear_password requires server-side plugin (PAM/LDAP) that requests it.
 # Our docker setup doesn't trigger this path, so this is a baseline connectivity test.
 
+require "spec"
 require "../../src/mysql"
 
-tests = [
-  {"mysql://root@localhost:13307", "baseline connectivity"},
-]
-
-tests.each do |url, label|
-  begin
-    DB.open(url) do |db|
-      user = db.scalar("SELECT CURRENT_USER()").as(String)
-      puts "PASS: #{label} (user=#{user})"
+describe "mysql_clear_password authentication" do
+  [
+    {"mysql://root@localhost:13307", "baseline connectivity"},
+  ].each do |(url, label)|
+    it label do
+      DB.open(url) do |db|
+        db.scalar("SELECT CURRENT_USER()").as(String).should_not be_empty
+      end
     end
-  rescue ex
-    puts "FAIL: #{label} — #{ex.message}"
   end
 end

--- a/spec/manual/auth_native_test.cr
+++ b/spec/manual/auth_native_test.cr
@@ -1,21 +1,19 @@
 # Target: mysql57 (port 13306), mysql80_native (port 13308)
-# Run:    crystal run spec/manual/auth_native_test.cr
+# Run:    crystal spec spec/manual/auth_native_test.cr
 
+require "spec"
 require "../../src/mysql"
 
-tests = [
-  {"mysql://root@localhost:13306", "mysql57 root no password"},
-  {"mysql://root@localhost:13308", "mysql80_native root no password"},
-  {"mysql://native_user:native_pass@localhost:13308", "native_user with password"},
-]
-
-tests.each do |url, label|
-  begin
-    DB.open(url) do |db|
-      user = db.scalar("SELECT CURRENT_USER()").as(String)
-      puts "PASS: #{label} (user=#{user})"
+describe "mysql_native_password authentication" do
+  [
+    {"mysql://root@localhost:13306", "mysql57 root no password"},
+    {"mysql://root@localhost:13308", "mysql80_native root no password"},
+    {"mysql://native_user:native_pass@localhost:13308", "native_user with password"},
+  ].each do |(url, label)|
+    it label do
+      DB.open(url) do |db|
+        db.scalar("SELECT CURRENT_USER()").as(String).should_not be_empty
+      end
     end
-  rescue ex
-    puts "FAIL: #{label} — #{ex.message}"
   end
 end

--- a/spec/manual/auth_native_test.cr
+++ b/spec/manual/auth_native_test.cr
@@ -1,0 +1,21 @@
+# Target: mysql57 (port 13306), mysql80_native (port 13308)
+# Run:    crystal run spec/manual/auth_native_test.cr
+
+require "../../src/mysql"
+
+tests = [
+  {"mysql://root@localhost:13306", "mysql57 root no password"},
+  {"mysql://root@localhost:13308", "mysql80_native root no password"},
+  {"mysql://native_user:native_pass@localhost:13308", "native_user with password"},
+]
+
+tests.each do |url, label|
+  begin
+    DB.open(url) do |db|
+      user = db.scalar("SELECT CURRENT_USER()").as(String)
+      puts "PASS: #{label} (user=#{user})"
+    end
+  rescue ex
+    puts "FAIL: #{label} — #{ex.message}"
+  end
+end

--- a/spec/manual/auth_sha256_test.cr
+++ b/spec/manual/auth_sha256_test.cr
@@ -1,23 +1,20 @@
 # Target: mysql80 (port 13307)
-# Run:    crystal run spec/manual/auth_sha256_test.cr
+# Run:    crystal spec spec/manual/auth_sha256_test.cr
 #
 # Tests sha256_password authentication.
-# Expected to FAIL with current code.
 
+require "spec"
 require "../../src/mysql"
 
-tests = [
-  {"mysql://sha256_user:sha256_pass@localhost:13307", "sha256_user over TLS"},
-  {"mysql://sha256_user:sha256_pass@localhost:13307?ssl-mode=disabled", "sha256_user without TLS"},
-]
-
-tests.each do |url, label|
-  begin
-    DB.open(url) do |db|
-      user = db.scalar("SELECT CURRENT_USER()").as(String)
-      puts "PASS: #{label} (user=#{user})"
+describe "sha256_password authentication" do
+  [
+    {"mysql://sha256_user:sha256_pass@localhost:13307", "sha256_user over TLS"},
+    {"mysql://sha256_user:sha256_pass@localhost:13307?ssl-mode=disabled", "sha256_user without TLS"},
+  ].each do |(url, label)|
+    it label do
+      DB.open(url) do |db|
+        db.scalar("SELECT CURRENT_USER()").as(String).should_not be_empty
+      end
     end
-  rescue ex
-    puts "FAIL: #{label} — #{ex.message}"
   end
 end

--- a/spec/manual/auth_sha256_test.cr
+++ b/spec/manual/auth_sha256_test.cr
@@ -1,0 +1,23 @@
+# Target: mysql80 (port 13307)
+# Run:    crystal run spec/manual/auth_sha256_test.cr
+#
+# Tests sha256_password authentication.
+# Expected to FAIL with current code.
+
+require "../../src/mysql"
+
+tests = [
+  {"mysql://sha256_user:sha256_pass@localhost:13307", "sha256_user over TLS"},
+  {"mysql://sha256_user:sha256_pass@localhost:13307?ssl-mode=disabled", "sha256_user without TLS"},
+]
+
+tests.each do |url, label|
+  begin
+    DB.open(url) do |db|
+      user = db.scalar("SELECT CURRENT_USER()").as(String)
+      puts "PASS: #{label} (user=#{user})"
+    end
+  rescue ex
+    puts "FAIL: #{label} — #{ex.message}"
+  end
+end

--- a/spec/manual/auth_switch_test.cr
+++ b/spec/manual/auth_switch_test.cr
@@ -1,0 +1,23 @@
+# Target: mysql80 (port 13307), mysql80_native (port 13308)
+# Run:    crystal run spec/manual/auth_switch_test.cr
+#
+# Tests AuthSwitchRequest handling.
+# Expected to FAIL with current code.
+
+require "../../src/mysql"
+
+tests = [
+  {"mysql://native_user:native_pass@localhost:13307", "auth switch csha2 -> native"},
+  {"mysql://csha2_user:csha2_pass@localhost:13308", "auth switch native -> csha2"},
+]
+
+tests.each do |url, label|
+  begin
+    DB.open(url) do |db|
+      user = db.scalar("SELECT CURRENT_USER()").as(String)
+      puts "PASS: #{label} (user=#{user})"
+    end
+  rescue ex
+    puts "FAIL: #{label} — #{ex.message}"
+  end
+end

--- a/spec/manual/auth_switch_test.cr
+++ b/spec/manual/auth_switch_test.cr
@@ -1,23 +1,20 @@
 # Target: mysql80 (port 13307), mysql80_native (port 13308)
-# Run:    crystal run spec/manual/auth_switch_test.cr
+# Run:    crystal spec spec/manual/auth_switch_test.cr
 #
 # Tests AuthSwitchRequest handling.
-# Expected to FAIL with current code.
 
+require "spec"
 require "../../src/mysql"
 
-tests = [
-  {"mysql://native_user:native_pass@localhost:13307", "auth switch csha2 -> native"},
-  {"mysql://csha2_user:csha2_pass@localhost:13308", "auth switch native -> csha2"},
-]
-
-tests.each do |url, label|
-  begin
-    DB.open(url) do |db|
-      user = db.scalar("SELECT CURRENT_USER()").as(String)
-      puts "PASS: #{label} (user=#{user})"
+describe "AuthSwitchRequest handling" do
+  [
+    {"mysql://native_user:native_pass@localhost:13307", "auth switch csha2 -> native"},
+    {"mysql://csha2_user:csha2_pass@localhost:13308", "auth switch native -> csha2"},
+  ].each do |(url, label)|
+    it label do
+      DB.open(url) do |db|
+        db.scalar("SELECT CURRENT_USER()").as(String).should_not be_empty
+      end
     end
-  rescue ex
-    puts "FAIL: #{label} — #{ex.message}"
   end
 end

--- a/spec/manual/run_auth_tests.sh
+++ b/spec/manual/run_auth_tests.sh
@@ -3,8 +3,7 @@
 # Run all manual auth tests against docker-compose.auth-test.yml containers.
 #
 # Usage:
-#   spec/manual/run_auth_tests.sh          # build and run
-#   spec/manual/run_auth_tests.sh --skip-build  # run only (binaries must exist)
+#   spec/manual/run_auth_tests.sh
 #
 # Prerequisites:
 #   docker compose -f docker-compose.auth-test.yml up -d
@@ -14,20 +13,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-BUILD_DIR="${TMPDIR:-/tmp}/crystal-mysql-auth-tests"
-
-TESTS=(
-  auth_native_test
-  auth_caching_sha2_test
-  auth_switch_test
-  auth_sha256_test
-  auth_clear_password_test
-)
-
-skip_build=false
-if [[ "${1:-}" == "--skip-build" ]]; then
-  skip_build=true
-fi
 
 # Check containers are running
 if ! docker compose -f "$PROJECT_DIR/docker-compose.auth-test.yml" ps --format '{{.Service}}' 2>/dev/null | grep -q mysql80; then
@@ -37,48 +22,5 @@ if ! docker compose -f "$PROJECT_DIR/docker-compose.auth-test.yml" ps --format '
   exit 1
 fi
 
-mkdir -p "$BUILD_DIR"
-
-# Build
-if [[ "$skip_build" == false ]]; then
-  echo "Building test binaries..."
-  for test in "${TESTS[@]}"; do
-    echo "  $test"
-    crystal build "$SCRIPT_DIR/$test.cr" -o "$BUILD_DIR/$test" 2>&1
-  done
-  echo ""
-fi
-
-# Run
-pass=0
-fail=0
-total=0
-
-for test in "${TESTS[@]}"; do
-  binary="$BUILD_DIR/$test"
-  if [[ ! -x "$binary" ]]; then
-    echo "SKIP: $test (not built)"
-    continue
-  fi
-
-  echo "=== $test ==="
-  while IFS= read -r line; do
-    total=$((total + 1))
-    if [[ "$line" == PASS:* ]]; then
-      pass=$((pass + 1))
-    elif [[ "$line" == FAIL:* ]]; then
-      fail=$((fail + 1))
-    fi
-    echo "  $line"
-  done < <("$binary" 2>&1)
-  echo ""
-done
-
-# Summary
-echo "==============================="
-echo "Results: $pass passed, $fail failed, $total total"
-echo "==============================="
-
-if [[ $fail -gt 0 ]]; then
-  exit 1
-fi
+cd "$PROJECT_DIR"
+crystal spec spec/manual/*_test.cr

--- a/spec/manual/run_auth_tests.sh
+++ b/spec/manual/run_auth_tests.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Run all manual auth tests against docker-compose.auth-test.yml containers.
+#
+# Usage:
+#   spec/manual/run_auth_tests.sh          # build and run
+#   spec/manual/run_auth_tests.sh --skip-build  # run only (binaries must exist)
+#
+# Prerequisites:
+#   docker compose -f docker-compose.auth-test.yml up -d
+#   Wait ~15s for MySQL containers to initialize.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/crystal-mysql-auth-tests"
+
+TESTS=(
+  auth_native_test
+  auth_caching_sha2_test
+  auth_switch_test
+  auth_sha256_test
+  auth_clear_password_test
+)
+
+skip_build=false
+if [[ "${1:-}" == "--skip-build" ]]; then
+  skip_build=true
+fi
+
+# Check containers are running
+if ! docker compose -f "$PROJECT_DIR/docker-compose.auth-test.yml" ps --format '{{.Service}}' 2>/dev/null | grep -q mysql80; then
+  echo "ERROR: Docker containers not running. Start them with:"
+  echo "  docker compose -f docker-compose.auth-test.yml up -d"
+  echo "  # wait ~15s for init"
+  exit 1
+fi
+
+mkdir -p "$BUILD_DIR"
+
+# Build
+if [[ "$skip_build" == false ]]; then
+  echo "Building test binaries..."
+  for test in "${TESTS[@]}"; do
+    echo "  $test"
+    crystal build "$SCRIPT_DIR/$test.cr" -o "$BUILD_DIR/$test" 2>&1
+  done
+  echo ""
+fi
+
+# Run
+pass=0
+fail=0
+total=0
+
+for test in "${TESTS[@]}"; do
+  binary="$BUILD_DIR/$test"
+  if [[ ! -x "$binary" ]]; then
+    echo "SKIP: $test (not built)"
+    continue
+  fi
+
+  echo "=== $test ==="
+  while IFS= read -r line; do
+    total=$((total + 1))
+    if [[ "$line" == PASS:* ]]; then
+      pass=$((pass + 1))
+    elif [[ "$line" == FAIL:* ]]; then
+      fail=$((fail + 1))
+    fi
+    echo "  $line"
+  done < <("$binary" 2>&1)
+  echo ""
+done
+
+# Summary
+echo "==============================="
+echo "Results: $pass passed, $fail failed, $total total"
+echo "==============================="
+
+if [[ $fail -gt 0 ]]; then
+  exit 1
+fi

--- a/src/mysql/auth.cr
+++ b/src/mysql/auth.cr
@@ -89,7 +89,11 @@ module MySql::Auth
     result
   end
 
-  RSA_PKCS1_OAEP_PADDING = 4
+  # Constants from OpenSSL evp.h
+  EVP_PKEY_RSA              =  6
+  EVP_PKEY_OP_ENCRYPT       =  1 << 9
+  EVP_PKEY_CTRL_RSA_PADDING = 0x1001
+  RSA_PKCS1_OAEP_PADDING    =  4
 
   def self.rsa_encrypt_password(password : String, scramble : Bytes, pem_key : String) : Bytes
     xored = xor_password_scramble(password, scramble)
@@ -111,8 +115,7 @@ module MySql::Auth
           end
 
           # Set RSA OAEP padding
-          # EVP_PKEY_RSA=6, EVP_PKEY_OP_ENCRYPT=1<<9, EVP_PKEY_CTRL_RSA_PADDING=0x1001
-          if LibCrypto.evp_pkey_ctx_ctrl(ctx, 6, 1 << 9, 0x1001, RSA_PKCS1_OAEP_PADDING, nil) <= 0
+          if LibCrypto.evp_pkey_ctx_ctrl(ctx, EVP_PKEY_RSA, EVP_PKEY_OP_ENCRYPT, EVP_PKEY_CTRL_RSA_PADDING, RSA_PKCS1_OAEP_PADDING, nil) <= 0
             raise Connection::PacketError.new("Failed to set RSA OAEP padding")
           end
 

--- a/src/mysql/auth.cr
+++ b/src/mysql/auth.cr
@@ -1,8 +1,20 @@
 require "openssl/sha1"
 require "openssl/digest"
 
+# Reopen Crystal's LibCrypto to add RSA encryption bindings for MySQL auth
+lib LibCrypto
+  fun bio_new_mem_buf = BIO_new_mem_buf(buf : Void*, len : Int32) : Bio*
+  fun pem_read_bio_pubkey = PEM_read_bio_PUBKEY(bio : Bio*, x : Void*, cb : Void*, u : Void*) : Void*
+  fun evp_pkey_free = EVP_PKEY_free(pkey : Void*)
+  fun evp_pkey_ctx_new = EVP_PKEY_CTX_new(pkey : Void*, e : Void*) : Void*
+  fun evp_pkey_ctx_free = EVP_PKEY_CTX_free(ctx : Void*)
+  fun evp_pkey_encrypt_init = EVP_PKEY_encrypt_init(ctx : Void*) : Int32
+  fun evp_pkey_ctx_ctrl = EVP_PKEY_CTX_ctrl(ctx : Void*, keytype : Int32, optype : Int32, cmd : Int32, p1 : Int32, p2 : Void*) : Int32
+  fun evp_pkey_encrypt = EVP_PKEY_encrypt(ctx : Void*, out : UInt8*, outlen : LibC::SizeT*, in_buf : UInt8*, inlen : LibC::SizeT) : Int32
+end
+
 module MySql::Auth
-  def self.compute_auth_response(plugin_name : String, password : String?, scramble : Bytes) : Bytes
+  def self.compute_auth_response(plugin_name : String, password : String?, scramble : Bytes, ssl_established : Bool = false) : Bytes
     if password.nil? || password.empty?
       return Bytes.empty
     end
@@ -13,7 +25,13 @@ module MySql::Auth
     when "caching_sha2_password"
       caching_sha2_password(password, scramble)
     when "sha256_password"
-      Bytes[0x01]
+      if ssl_established
+        # Over TLS: send plaintext password null-terminated
+        clear_password(password)
+      else
+        # Without TLS: send 0x01 to request RSA public key
+        Bytes[0x01]
+      end
     when "mysql_clear_password"
       clear_password(password)
     else
@@ -69,18 +87,6 @@ module MySql::Auth
     result
   end
 
-  # Reopen Crystal's LibCrypto to add RSA encryption bindings for MySQL auth
-  lib LibCrypto
-    fun bio_new_mem_buf = BIO_new_mem_buf(buf : Void*, len : Int32) : Void*
-    fun pem_read_bio_pubkey = PEM_read_bio_PUBKEY(bio : Void*, x : Void*, cb : Void*, u : Void*) : Void*
-    fun evp_pkey_free = EVP_PKEY_free(pkey : Void*)
-    fun evp_pkey_ctx_new = EVP_PKEY_CTX_new(pkey : Void*, e : Void*) : Void*
-    fun evp_pkey_ctx_free = EVP_PKEY_CTX_free(ctx : Void*)
-    fun evp_pkey_encrypt_init = EVP_PKEY_encrypt_init(ctx : Void*) : Int32
-    fun evp_pkey_ctx_ctrl = EVP_PKEY_CTX_ctrl(ctx : Void*, keytype : Int32, optype : Int32, cmd : Int32, p1 : Int32, p2 : Void*) : Int32
-    fun evp_pkey_encrypt = EVP_PKEY_encrypt(ctx : Void*, out : UInt8*, outlen : LibC::SizeT*, in_buf : UInt8*, inlen : LibC::SizeT) : Int32
-  end
-
   def self.rsa_encrypt_password(password : String, scramble : Bytes, pem_key : String) : Bytes
     xored = xor_password_scramble(password, scramble)
 
@@ -101,12 +107,8 @@ module MySql::Auth
           end
 
           # Set RSA OAEP padding
-          evp_pkey_rsa = 6
-          evp_pkey_op_encrypt = 1 << 9
-          evp_pkey_ctrl_rsa_padding = 0x1001
-          rsa_pkcs1_oaep_padding = 4
-
-          if LibCrypto.evp_pkey_ctx_ctrl(ctx, evp_pkey_rsa, evp_pkey_op_encrypt, evp_pkey_ctrl_rsa_padding, rsa_pkcs1_oaep_padding, nil) <= 0
+          # EVP_PKEY_RSA=6, EVP_PKEY_OP_ENCRYPT=1<<9, EVP_PKEY_CTRL_RSA_PADDING=0x1001, RSA_PKCS1_OAEP_PADDING=4
+          if LibCrypto.evp_pkey_ctx_ctrl(ctx, 6, 1 << 9, 0x1001, 4, nil) <= 0
             raise Connection::PacketError.new("Failed to set RSA OAEP padding")
           end
 
@@ -130,7 +132,7 @@ module MySql::Auth
         LibCrypto.evp_pkey_free(pkey)
       end
     ensure
-      LibCrypto.BIO_free(bio.as(LibCrypto::Bio*))
+      LibCrypto.BIO_free(bio)
     end
   end
 

--- a/src/mysql/auth.cr
+++ b/src/mysql/auth.cr
@@ -90,10 +90,10 @@ module MySql::Auth
   end
 
   # Constants from OpenSSL evp.h
-  EVP_PKEY_RSA              =  6
-  EVP_PKEY_OP_ENCRYPT       =  1 << 9
+  EVP_PKEY_RSA              = 6
+  EVP_PKEY_OP_ENCRYPT       = 1 << 9
   EVP_PKEY_CTRL_RSA_PADDING = 0x1001
-  RSA_PKCS1_OAEP_PADDING    =  4
+  RSA_PKCS1_OAEP_PADDING    =      4
 
   def self.rsa_encrypt_password(password : String, scramble : Bytes, pem_key : String) : Bytes
     xored = xor_password_scramble(password, scramble)

--- a/src/mysql/auth.cr
+++ b/src/mysql/auth.cr
@@ -69,6 +69,10 @@ module MySql::Auth
     result
   end
 
+  def self.rsa_encrypt_password(password : String, scramble : Bytes, pem_key : String) : Bytes
+    raise "RSA encryption not yet implemented"
+  end
+
   private def self.sha256(data : Bytes) : Bytes
     digest = OpenSSL::Digest.new("SHA256")
     digest.update(data)

--- a/src/mysql/auth.cr
+++ b/src/mysql/auth.cr
@@ -69,8 +69,69 @@ module MySql::Auth
     result
   end
 
+  # Reopen Crystal's LibCrypto to add RSA encryption bindings for MySQL auth
+  lib LibCrypto
+    fun bio_new_mem_buf = BIO_new_mem_buf(buf : Void*, len : Int32) : Void*
+    fun pem_read_bio_pubkey = PEM_read_bio_PUBKEY(bio : Void*, x : Void*, cb : Void*, u : Void*) : Void*
+    fun evp_pkey_free = EVP_PKEY_free(pkey : Void*)
+    fun evp_pkey_ctx_new = EVP_PKEY_CTX_new(pkey : Void*, e : Void*) : Void*
+    fun evp_pkey_ctx_free = EVP_PKEY_CTX_free(ctx : Void*)
+    fun evp_pkey_encrypt_init = EVP_PKEY_encrypt_init(ctx : Void*) : Int32
+    fun evp_pkey_ctx_ctrl = EVP_PKEY_CTX_ctrl(ctx : Void*, keytype : Int32, optype : Int32, cmd : Int32, p1 : Int32, p2 : Void*) : Int32
+    fun evp_pkey_encrypt = EVP_PKEY_encrypt(ctx : Void*, out : UInt8*, outlen : LibC::SizeT*, in_buf : UInt8*, inlen : LibC::SizeT) : Int32
+  end
+
   def self.rsa_encrypt_password(password : String, scramble : Bytes, pem_key : String) : Bytes
-    raise "RSA encryption not yet implemented"
+    xored = xor_password_scramble(password, scramble)
+
+    bio = LibCrypto.bio_new_mem_buf(pem_key.to_unsafe.as(Void*), pem_key.bytesize)
+    raise Connection::PacketError.new("Failed to create BIO for RSA key") if bio.null?
+
+    begin
+      pkey = LibCrypto.pem_read_bio_pubkey(bio, nil, nil, nil)
+      raise Connection::PacketError.new("Failed to parse RSA public key") if pkey.null?
+
+      begin
+        ctx = LibCrypto.evp_pkey_ctx_new(pkey, nil)
+        raise Connection::PacketError.new("Failed to create EVP_PKEY_CTX") if ctx.null?
+
+        begin
+          if LibCrypto.evp_pkey_encrypt_init(ctx) <= 0
+            raise Connection::PacketError.new("EVP_PKEY_encrypt_init failed")
+          end
+
+          # Set RSA OAEP padding
+          evp_pkey_rsa = 6
+          evp_pkey_op_encrypt = 1 << 9
+          evp_pkey_ctrl_rsa_padding = 0x1001
+          rsa_pkcs1_oaep_padding = 4
+
+          if LibCrypto.evp_pkey_ctx_ctrl(ctx, evp_pkey_rsa, evp_pkey_op_encrypt, evp_pkey_ctrl_rsa_padding, rsa_pkcs1_oaep_padding, nil) <= 0
+            raise Connection::PacketError.new("Failed to set RSA OAEP padding")
+          end
+
+          # Determine output size
+          out_len = LibC::SizeT.new(0)
+          if LibCrypto.evp_pkey_encrypt(ctx, nil, pointerof(out_len), xored.to_unsafe, LibC::SizeT.new(xored.size)) <= 0
+            raise Connection::PacketError.new("EVP_PKEY_encrypt size determination failed")
+          end
+
+          # Encrypt
+          encrypted = Bytes.new(out_len.to_i32)
+          if LibCrypto.evp_pkey_encrypt(ctx, encrypted.to_unsafe, pointerof(out_len), xored.to_unsafe, LibC::SizeT.new(xored.size)) <= 0
+            raise Connection::PacketError.new("RSA encryption failed")
+          end
+
+          encrypted[0, out_len.to_i32]
+        ensure
+          LibCrypto.evp_pkey_ctx_free(ctx)
+        end
+      ensure
+        LibCrypto.evp_pkey_free(pkey)
+      end
+    ensure
+      LibCrypto.BIO_free(bio.as(LibCrypto::Bio*))
+    end
   end
 
   private def self.sha256(data : Bytes) : Bytes

--- a/src/mysql/auth.cr
+++ b/src/mysql/auth.cr
@@ -11,6 +11,7 @@ lib LibCrypto
   fun evp_pkey_encrypt_init = EVP_PKEY_encrypt_init(ctx : Void*) : Int32
   fun evp_pkey_ctx_ctrl = EVP_PKEY_CTX_ctrl(ctx : Void*, keytype : Int32, optype : Int32, cmd : Int32, p1 : Int32, p2 : Void*) : Int32
   fun evp_pkey_encrypt = EVP_PKEY_encrypt(ctx : Void*, out : UInt8*, outlen : LibC::SizeT*, in_buf : UInt8*, inlen : LibC::SizeT) : Int32
+  fun evp_pkey_ctx_set_rsa_oaep_md = EVP_PKEY_CTX_set_rsa_oaep_md(ctx : Void*, md : EVP_MD) : Int32
 end
 
 module MySql::Auth
@@ -83,9 +84,12 @@ module MySql::Auth
     pass_bytes.size.times do |i|
       result[i] = pass_bytes[i] ^ scramble[i % scramble.size]
     end
-    result[pass_bytes.size] = 0_u8
+    # XOR the null terminator too (matches MySQL protocol spec)
+    result[pass_bytes.size] = 0_u8 ^ scramble[pass_bytes.size % scramble.size]
     result
   end
+
+  RSA_PKCS1_OAEP_PADDING = 4
 
   def self.rsa_encrypt_password(password : String, scramble : Bytes, pem_key : String) : Bytes
     xored = xor_password_scramble(password, scramble)
@@ -107,9 +111,14 @@ module MySql::Auth
           end
 
           # Set RSA OAEP padding
-          # EVP_PKEY_RSA=6, EVP_PKEY_OP_ENCRYPT=1<<9, EVP_PKEY_CTRL_RSA_PADDING=0x1001, RSA_PKCS1_OAEP_PADDING=4
-          if LibCrypto.evp_pkey_ctx_ctrl(ctx, 6, 1 << 9, 0x1001, 4, nil) <= 0
+          # EVP_PKEY_RSA=6, EVP_PKEY_OP_ENCRYPT=1<<9, EVP_PKEY_CTRL_RSA_PADDING=0x1001
+          if LibCrypto.evp_pkey_ctx_ctrl(ctx, 6, 1 << 9, 0x1001, RSA_PKCS1_OAEP_PADDING, nil) <= 0
             raise Connection::PacketError.new("Failed to set RSA OAEP padding")
+          end
+
+          # Set OAEP digest to SHA-1 (MySQL expects SHA-1, OpenSSL 3.x may default to SHA-256)
+          if LibCrypto.evp_pkey_ctx_set_rsa_oaep_md(ctx, LibCrypto.evp_sha1) <= 0
+            raise Connection::PacketError.new("Failed to set OAEP digest to SHA-1")
           end
 
           # Determine output size

--- a/src/mysql/auth.cr
+++ b/src/mysql/auth.cr
@@ -1,0 +1,77 @@
+require "openssl/sha1"
+require "openssl/digest"
+
+module MySql::Auth
+  def self.compute_auth_response(plugin_name : String, password : String?, scramble : Bytes) : Bytes
+    if password.nil? || password.empty?
+      return Bytes.empty
+    end
+
+    case plugin_name
+    when "mysql_native_password"
+      native_password(password, scramble)
+    when "caching_sha2_password"
+      caching_sha2_password(password, scramble)
+    when "sha256_password"
+      Bytes[0x01]
+    when "mysql_clear_password"
+      clear_password(password)
+    else
+      raise MySql::Connection::PacketError.new("Unsupported auth plugin: #{plugin_name}")
+    end
+  end
+
+  def self.native_password(password : String, scramble : Bytes) : Bytes
+    sizet_20 = LibC::SizeT.new(20)
+    sha1 = OpenSSL::SHA1.hash(password)
+    sha1sha1 = OpenSSL::SHA1.hash(sha1.to_unsafe, sizet_20)
+
+    buffer = Bytes.new(40)
+    buffer[0, 20].copy_from(scramble[0, 20])
+    buffer[20, 20].copy_from(sha1sha1.to_slice)
+
+    sizet_40 = LibC::SizeT.new(40)
+    buffer_sha1 = OpenSSL::SHA1.hash(buffer.to_unsafe, sizet_40)
+
+    result = Bytes.new(20)
+    20.times { |i| result[i] = sha1[i] ^ buffer_sha1[i] }
+    result
+  end
+
+  def self.caching_sha2_password(password : String, scramble : Bytes) : Bytes
+    hash1 = sha256(password.to_slice)
+    hash2 = sha256(hash1)
+
+    concat = Bytes.new(hash2.size + scramble.size)
+    concat[0, hash2.size].copy_from(hash2)
+    concat[hash2.size, scramble.size].copy_from(scramble)
+    hash3 = sha256(concat)
+
+    result = Bytes.new(32)
+    32.times { |i| result[i] = hash1[i] ^ hash3[i] }
+    result
+  end
+
+  def self.clear_password(password : String) : Bytes
+    bytes = Bytes.new(password.bytesize + 1)
+    bytes[0, password.bytesize].copy_from(password.to_slice)
+    bytes[password.bytesize] = 0_u8
+    bytes
+  end
+
+  def self.xor_password_scramble(password : String, scramble : Bytes) : Bytes
+    pass_bytes = password.to_slice
+    result = Bytes.new(pass_bytes.size + 1)
+    pass_bytes.size.times do |i|
+      result[i] = pass_bytes[i] ^ scramble[i % scramble.size]
+    end
+    result[pass_bytes.size] = 0_u8
+    result
+  end
+
+  private def self.sha256(data : Bytes) : Bytes
+    digest = OpenSSL::Digest.new("SHA256")
+    digest.update(data)
+    digest.final
+  end
+end

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -276,10 +276,8 @@ class MySql::Connection < DB::Connection
         # Full authentication required
         if ssl_established
           # Over TLS: send plaintext password null-terminated
-          pw = (password || "").to_slice
           write_packet(seq) do |pkt|
-            pkt.write(pw)
-            pkt.write_byte(0_u8)
+            pkt.write(Auth.clear_password(password || ""))
           end
           seq += 1
         else
@@ -309,10 +307,8 @@ class MySql::Connection < DB::Connection
       pem_data = packet.read_string(packet.remaining)
       if ssl_established
         # Over TLS: send plaintext password null-terminated
-        pw = (password || "").to_slice
         write_packet(seq) do |pkt|
-          pkt.write(pw)
-          pkt.write_byte(0_u8)
+          pkt.write(Auth.clear_password(password || ""))
         end
         seq += 1
       else

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -128,19 +128,21 @@ class MySql::Connection < DB::Connection
         # so the user would need to explicitly choose Disabled to avoid the ssl setup.
       end
 
+      ssl_established = @socket.is_a?(OpenSSL::SSL::Socket::Client)
+
       write_packet(seq) do |packet|
-        handshake_response.write(packet)
+        handshake_response.write(packet, ssl_established)
       end
       seq += 1
 
       # Auth state machine
       plugin_name = handshake.server_plugin_name
       scramble = handshake.auth_plugin_data
-      ssl_established = @socket.is_a?(OpenSSL::SSL::Socket::Client)
 
       auth_complete = false
       until auth_complete
         read_packet do |packet|
+          seq = packet.seq.to_i32 + 1
           status = packet.read_byte!
 
           case status
@@ -157,7 +159,7 @@ class MySql::Connection < DB::Connection
             bytes_read = packet.read(new_scramble).to_i
             scramble = new_scramble[0, bytes_read] if bytes_read > 0
 
-            auth_response = Auth.compute_auth_response(plugin_name, mysql_options.password, scramble)
+            auth_response = Auth.compute_auth_response(plugin_name, mysql_options.password, scramble, ssl_established)
             write_packet(seq) do |pkt|
               pkt.write(auth_response)
             end
@@ -269,9 +271,11 @@ class MySql::Connection < DB::Connection
       when 0x04
         # Full authentication required
         if ssl_established
-          xored = Auth.xor_password_scramble(password || "", scramble)
+          # Over TLS: send plaintext password null-terminated
+          pw = (password || "").to_slice
           write_packet(seq) do |pkt|
-            pkt.write(xored)
+            pkt.write(pw)
+            pkt.write_byte(0_u8)
           end
           seq += 1
         else
@@ -283,6 +287,7 @@ class MySql::Connection < DB::Connection
 
           # Read RSA public key
           read_packet do |key_packet|
+            seq = key_packet.seq.to_i32 + 1
             key_status = key_packet.read_byte!
             raise PacketError.new("Expected AuthMoreData with RSA key, got #{key_status}") unless key_status == 0x01
             pem_data = key_packet.read_string(key_packet.remaining)
@@ -299,9 +304,11 @@ class MySql::Connection < DB::Connection
     when "sha256_password"
       pem_data = packet.read_string(packet.remaining)
       if ssl_established
-        xored = Auth.xor_password_scramble(password || "", scramble)
+        # Over TLS: send plaintext password null-terminated
+        pw = (password || "").to_slice
         write_packet(seq) do |pkt|
-          pkt.write(xored)
+          pkt.write(pw)
+          pkt.write_byte(0_u8)
         end
         seq += 1
       else

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -109,7 +109,9 @@ class MySql::Connection < DB::Connection
 
       handshake = read_packet(Protocol::HandshakeV10)
 
-      handshake_response = Protocol::HandshakeResponse41.new(mysql_options.username, mysql_options.password, mysql_options.initial_catalog, handshake.auth_plugin_data, charset_id)
+      handshake_response = Protocol::HandshakeResponse41.new(
+        mysql_options.username, mysql_options.password, mysql_options.initial_catalog,
+        handshake.auth_plugin_data, charset_id, handshake.server_plugin_name)
       seq = 1
 
       if mysql_options.ssl_options.mode != SSLMode::Disabled &&
@@ -129,9 +131,44 @@ class MySql::Connection < DB::Connection
       write_packet(seq) do |packet|
         handshake_response.write(packet)
       end
+      seq += 1
 
-      read_ok_or_err do |packet, status|
-        raise "packet #{status} not implemented"
+      # Auth state machine
+      plugin_name = handshake.server_plugin_name
+      scramble = handshake.auth_plugin_data
+      ssl_established = @socket.is_a?(OpenSSL::SSL::Socket::Client)
+
+      auth_complete = false
+      until auth_complete
+        read_packet do |packet|
+          status = packet.read_byte!
+
+          case status
+          when 0x00
+            # OK packet — authentication successful
+            auth_complete = true
+          when 0xFF
+            # ERR packet
+            handle_err_packet(packet)
+          when 0xFE
+            # AuthSwitchRequest
+            plugin_name = packet.read_string
+            new_scramble = Bytes.new(20)
+            bytes_read = packet.read(new_scramble).to_i
+            scramble = new_scramble[0, bytes_read] if bytes_read > 0
+
+            auth_response = Auth.compute_auth_response(plugin_name, mysql_options.password, scramble)
+            write_packet(seq) do |pkt|
+              pkt.write(auth_response)
+            end
+            seq += 1
+          when 0x01
+            # AuthMoreData
+            seq = handle_auth_more_data(packet, plugin_name, mysql_options.password, scramble, ssl_established, seq)
+          else
+            raise PacketError.new("Unexpected auth packet status: #{status}")
+          end
+        end
       end
     rescue IO::Error
       raise DB::ConnectionRefused.new
@@ -220,6 +257,64 @@ class MySql::Connection < DB::Connection
     else
       raise PacketError.new(message)
     end
+  end
+
+  private def handle_auth_more_data(packet : ReadPacket, plugin_name : String, password : String?, scramble : Bytes, ssl_established : Bool, seq : Int32) : Int32
+    case plugin_name
+    when "caching_sha2_password"
+      flag = packet.read_byte!
+      case flag
+      when 0x03
+        # Fast auth success — next packet will be OK
+      when 0x04
+        # Full authentication required
+        if ssl_established
+          xored = Auth.xor_password_scramble(password || "", scramble)
+          write_packet(seq) do |pkt|
+            pkt.write(xored)
+          end
+          seq += 1
+        else
+          # Request RSA public key
+          write_packet(seq) do |pkt|
+            pkt.write_byte(0x02_u8)
+          end
+          seq += 1
+
+          # Read RSA public key
+          read_packet do |key_packet|
+            key_status = key_packet.read_byte!
+            raise PacketError.new("Expected AuthMoreData with RSA key, got #{key_status}") unless key_status == 0x01
+            pem_data = key_packet.read_string(key_packet.remaining)
+            encrypted = Auth.rsa_encrypt_password(password || "", scramble, pem_data)
+            write_packet(seq) do |pkt|
+              pkt.write(encrypted)
+            end
+            seq += 1
+          end
+        end
+      else
+        raise PacketError.new("Unexpected caching_sha2_password flag: #{flag}")
+      end
+    when "sha256_password"
+      pem_data = packet.read_string(packet.remaining)
+      if ssl_established
+        xored = Auth.xor_password_scramble(password || "", scramble)
+        write_packet(seq) do |pkt|
+          pkt.write(xored)
+        end
+        seq += 1
+      else
+        encrypted = Auth.rsa_encrypt_password(password || "", scramble, pem_data)
+        write_packet(seq) do |pkt|
+          pkt.write(encrypted)
+        end
+        seq += 1
+      end
+    else
+      raise PacketError.new("AuthMoreData not expected for plugin: #{plugin_name}")
+    end
+    seq
   end
 
   # :nodoc:

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -153,11 +153,15 @@ class MySql::Connection < DB::Connection
             # ERR packet
             handle_err_packet(packet)
           when 0xFE
-            # AuthSwitchRequest
+            # AuthSwitchRequest: 0xFE, plugin_name\0, plugin_data\0
             plugin_name = packet.read_string
-            new_scramble = Bytes.new(20)
-            bytes_read = packet.read(new_scramble).to_i
-            scramble = new_scramble[0, bytes_read] if bytes_read > 0
+            # Scramble is up to 20 random bytes (may contain 0x00 internally) followed
+            # by a trailing null. Bound to remaining-1 so the null stays for discard.
+            scramble_size = {20, packet.remaining - 1}.min
+            scramble_size = 0 if scramble_size < 0
+            new_scramble = Bytes.new(scramble_size)
+            packet.read_fully(new_scramble) if scramble_size > 0
+            scramble = new_scramble
 
             auth_response = Auth.compute_auth_response(plugin_name, mysql_options.password, scramble, ssl_established)
             write_packet(seq) do |pkt|

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -1,5 +1,6 @@
 require "socket"
 require "openssl"
+require "./auth"
 
 class MySql::Connection < DB::Connection
   class PacketError < Exception; end

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -140,7 +140,10 @@ class MySql::Connection < DB::Connection
       scramble = handshake.auth_plugin_data
 
       auth_complete = false
+      auth_iterations = 0
       until auth_complete
+        auth_iterations += 1
+        raise PacketError.new("Auth handshake did not complete after 10 packets") if auth_iterations > 10
         read_packet do |packet|
           seq = packet.seq.to_i32 + 1
           status = packet.read_byte!

--- a/src/mysql/connection.cr
+++ b/src/mysql/connection.cr
@@ -161,7 +161,7 @@ class MySql::Connection < DB::Connection
             scramble_size = 0 if scramble_size < 0
             new_scramble = Bytes.new(scramble_size)
             packet.read_fully(new_scramble) if scramble_size > 0
-            scramble = new_scramble
+            scramble = new_scramble if scramble_size > 0
 
             auth_response = Auth.compute_auth_response(plugin_name, mysql_options.password, scramble, ssl_established)
             write_packet(seq) do |pkt|

--- a/src/mysql/packets.cr
+++ b/src/mysql/packets.cr
@@ -1,9 +1,41 @@
+module MySql
+  # https://dev.mysql.com/doc/dev/mysql-server/latest/group__group__cs__capabilities__flags.html
+  @[Flags]
+  enum Capability : UInt32
+    LongPassword              = 0x00000001
+    FoundRows                 = 0x00000002
+    LongFlag                  = 0x00000004
+    ConnectWithDB             = 0x00000008
+    NoSchema                  = 0x00000010
+    Compress                  = 0x00000020
+    ODBC                      = 0x00000040
+    LocalFiles                = 0x00000080
+    IgnoreSpace               = 0x00000100
+    Protocol41                = 0x00000200
+    Interactive               = 0x00000400
+    SSL                       = 0x00000800
+    IgnoreSigpipe             = 0x00001000
+    Transactions              = 0x00002000
+    Reserved                  = 0x00004000
+    SecureConnection          = 0x00008000
+    MultiStatements           = 0x00010000
+    MultiResults              = 0x00020000
+    PSMultiResults            = 0x00040000
+    PluginAuth                = 0x00080000
+    ConnectAttrs              = 0x00100000
+    PluginAuthLenencClientData = 0x00200000
+    CanHandleExpiredPasswords = 0x00400000
+    SessionTrack              = 0x00800000
+    DeprecateEOF              = 0x01000000
+  end
+end
+
 module MySql::Protocol
   # https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_v10.html
   struct HandshakeV10
     getter auth_plugin_data : Bytes
     getter charset : UInt8
-    getter server_capabilities : UInt32
+    getter server_capabilities : Capability
     getter server_plugin_name : String
 
     def initialize(@auth_plugin_data, @charset, @server_capabilities, @server_plugin_name)
@@ -24,7 +56,7 @@ module MySql::Protocol
       cap3 = packet.read_byte!
       cap4 = packet.read_byte!
 
-      server_capabilities = cap1.to_u32 | (cap2.to_u32 << 8) | (cap3.to_u32 << 16) | (cap4.to_u32 << 24)
+      server_capabilities = Capability.new(cap1.to_u32 | (cap2.to_u32 << 8) | (cap3.to_u32 << 16) | (cap4.to_u32 << 24))
 
       auth_plugin_data_length = packet.read_byte!
       packet.read_byte_array(10)
@@ -38,41 +70,15 @@ module MySql::Protocol
 
   # https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_response.html#sect_protocol_connection_phase_packets_protocol_handshake_response41
   struct HandshakeResponse41
-    CLIENT_LONG_PASSWORD                  = 0x00000001
-    CLIENT_FOUND_ROWS                     = 0x00000002
-    CLIENT_LONG_FLAG                      = 0x00000004
-    CLIENT_CONNECT_WITH_DB                = 0x00000008
-    CLIENT_NO_SCHEMA                      = 0x00000010
-    CLIENT_COMPRESS                       = 0x00000020
-    CLIENT_ODBC                           = 0x00000040
-    CLIENT_LOCAL_FILES                    = 0x00000080
-    CLIENT_IGNORE_SPACE                   = 0x00000100
-    CLIENT_PROTOCOL_41                    = 0x00000200
-    CLIENT_INTERACTIVE                    = 0x00000400
-    CLIENT_SSL                            = 0x00000800
-    CLIENT_IGNORE_SIGPIPE                 = 0x00001000
-    CLIENT_TRANSACTIONS                   = 0x00002000
-    CLIENT_RESERVED                       = 0x00004000
-    CLIENT_SECURE_CONNECTION              = 0x00008000
-    CLIENT_MULTI_STATEMENTS               = 0x00010000
-    CLIENT_MULTI_RESULTS                  = 0x00020000
-    CLIENT_PS_MULTI_RESULTS               = 0x00040000
-    CLIENT_PLUGIN_AUTH                    = 0x00080000
-    CLIENT_CONNECT_ATTRS                  = 0x00100000
-    CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 0x00200000
-    CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS   = 0x00400000
-    CLIENT_SESSION_TRACK                  = 0x00800000
-    CLIENT_DEPRECATE_EOF                  = 0x01000000
-
     def initialize(@username : String?, @password : String?, @initial_catalog : String?, @auth_plugin_data : Bytes, @charset : UInt8, @plugin_name : String = "mysql_native_password")
     end
 
     # https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_ssl_request.html
     def write_ssl_request(packet : MySql::WritePacket)
-      caps = CLIENT_PROTOCOL_41 | CLIENT_SSL
-      caps |= CLIENT_CONNECT_WITH_DB if @initial_catalog
+      caps = Capability::Protocol41 | Capability::SSL
+      caps |= Capability::ConnectWithDB if @initial_catalog
 
-      packet.write_bytes caps, IO::ByteFormat::LittleEndian
+      packet.write_bytes caps.value, IO::ByteFormat::LittleEndian
 
       packet.write_bytes 0x00000000u32, IO::ByteFormat::LittleEndian
       packet.write_byte @charset
@@ -80,10 +86,10 @@ module MySql::Protocol
     end
 
     def write(packet : MySql::WritePacket)
-      caps = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA | CLIENT_PLUGIN_AUTH
-      caps |= CLIENT_CONNECT_WITH_DB if @initial_catalog
+      caps = Capability::Protocol41 | Capability::SecureConnection | Capability::PluginAuthLenencClientData | Capability::PluginAuth
+      caps |= Capability::ConnectWithDB if @initial_catalog
 
-      packet.write_bytes caps, IO::ByteFormat::LittleEndian
+      packet.write_bytes caps.value, IO::ByteFormat::LittleEndian
       packet.write_bytes 0x00000000u32, IO::ByteFormat::LittleEndian
       packet.write_byte @charset
       23.times { packet.write_byte 0_u8 }

--- a/src/mysql/packets.cr
+++ b/src/mysql/packets.cr
@@ -2,31 +2,31 @@ module MySql
   # https://dev.mysql.com/doc/dev/mysql-server/latest/group__group__cs__capabilities__flags.html
   @[Flags]
   enum Capability : UInt32
-    LongPassword              = 0x00000001
-    FoundRows                 = 0x00000002
-    LongFlag                  = 0x00000004
-    ConnectWithDB             = 0x00000008
-    NoSchema                  = 0x00000010
-    Compress                  = 0x00000020
-    ODBC                      = 0x00000040
-    LocalFiles                = 0x00000080
-    IgnoreSpace               = 0x00000100
-    Protocol41                = 0x00000200
-    Interactive               = 0x00000400
-    SSL                       = 0x00000800
-    IgnoreSigpipe             = 0x00001000
-    Transactions              = 0x00002000
-    Reserved                  = 0x00004000
-    SecureConnection          = 0x00008000
-    MultiStatements           = 0x00010000
-    MultiResults              = 0x00020000
-    PSMultiResults            = 0x00040000
-    PluginAuth                = 0x00080000
-    ConnectAttrs              = 0x00100000
+    LongPassword               = 0x00000001
+    FoundRows                  = 0x00000002
+    LongFlag                   = 0x00000004
+    ConnectWithDB              = 0x00000008
+    NoSchema                   = 0x00000010
+    Compress                   = 0x00000020
+    ODBC                       = 0x00000040
+    LocalFiles                 = 0x00000080
+    IgnoreSpace                = 0x00000100
+    Protocol41                 = 0x00000200
+    Interactive                = 0x00000400
+    SSL                        = 0x00000800
+    IgnoreSigpipe              = 0x00001000
+    Transactions               = 0x00002000
+    Reserved                   = 0x00004000
+    SecureConnection           = 0x00008000
+    MultiStatements            = 0x00010000
+    MultiResults               = 0x00020000
+    PSMultiResults             = 0x00040000
+    PluginAuth                 = 0x00080000
+    ConnectAttrs               = 0x00100000
     PluginAuthLenencClientData = 0x00200000
-    CanHandleExpiredPasswords = 0x00400000
-    SessionTrack              = 0x00800000
-    DeprecateEOF              = 0x01000000
+    CanHandleExpiredPasswords  = 0x00400000
+    SessionTrack               = 0x00800000
+    DeprecateEOF               = 0x01000000
   end
 end
 

--- a/src/mysql/packets.cr
+++ b/src/mysql/packets.cr
@@ -1,5 +1,3 @@
-require "openssl/sha1"
-
 module MySql::Protocol
   # https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_v10.html
   struct HandshakeV10
@@ -66,7 +64,7 @@ module MySql::Protocol
     CLIENT_SESSION_TRACK                  = 0x00800000
     CLIENT_DEPRECATE_EOF                  = 0x01000000
 
-    def initialize(@username : String?, @password : String?, @initial_catalog : String?, @auth_plugin_data : Bytes, @charset : UInt8)
+    def initialize(@username : String?, @password : String?, @initial_catalog : String?, @auth_plugin_data : Bytes, @charset : UInt8, @plugin_name : String = "mysql_native_password")
     end
 
     # https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_ssl_request.html
@@ -82,14 +80,10 @@ module MySql::Protocol
     end
 
     def write(packet : MySql::WritePacket)
-      caps = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA
-
-      caps |= CLIENT_PLUGIN_AUTH if @password
-
+      caps = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA | CLIENT_PLUGIN_AUTH
       caps |= CLIENT_CONNECT_WITH_DB if @initial_catalog
 
       packet.write_bytes caps, IO::ByteFormat::LittleEndian
-
       packet.write_bytes 0x00000000u32, IO::ByteFormat::LittleEndian
       packet.write_byte @charset
       23.times { packet.write_byte 0_u8 }
@@ -97,30 +91,12 @@ module MySql::Protocol
       packet << @username
       packet.write_byte 0_u8
 
-      if password = @password
-        sizet_20 = LibC::SizeT.new(20)
-        sha1 = OpenSSL::SHA1.hash(password)
-        sha1sha1 = OpenSSL::SHA1.hash(sha1.to_unsafe, sizet_20)
-
-        buffer = uninitialized UInt8[40]
-        buffer.to_unsafe.copy_from(@auth_plugin_data.to_unsafe, 20)
-        (buffer.to_unsafe + 20).copy_from(sha1sha1.to_unsafe, 20)
-
-        sizet_40 = LibC::SizeT.new(40)
-        buffer_sha1 = OpenSSL::SHA1.hash(buffer.to_unsafe, sizet_40)
-
-        # reuse buffer
-        20.times { |i|
-          buffer[i] = sha1[i] ^ buffer_sha1[i]
-        }
-
-        auth_response = Bytes.new(buffer.to_unsafe, 20)
-
-        # packet.write_byte 0_u8
-        packet.write_lenenc_int 20
-        packet.write(auth_response)
-      else
+      auth_response = Auth.compute_auth_response(@plugin_name, @password, @auth_plugin_data)
+      if auth_response.empty?
         packet.write_byte 0_u8
+      else
+        packet.write_lenenc_int auth_response.size
+        packet.write(auth_response)
       end
 
       if initial_catalog = @initial_catalog
@@ -128,10 +104,8 @@ module MySql::Protocol
         packet.write_byte 0_u8
       end
 
-      if @password
-        packet << "mysql_native_password"
-        packet.write_byte 0_u8
-      end
+      packet << @plugin_name
+      packet.write_byte 0_u8
     end
   end
 

--- a/src/mysql/packets.cr
+++ b/src/mysql/packets.cr
@@ -1,11 +1,14 @@
 require "openssl/sha1"
 
 module MySql::Protocol
+  # https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_v10.html
   struct HandshakeV10
     getter auth_plugin_data : Bytes
     getter charset : UInt8
+    getter server_capabilities : UInt32
+    getter server_plugin_name : String
 
-    def initialize(@auth_plugin_data, @charset)
+    def initialize(@auth_plugin_data, @charset, @server_capabilities, @server_plugin_name)
     end
 
     def self.read(packet : MySql::ReadPacket)
@@ -23,13 +26,15 @@ module MySql::Protocol
       cap3 = packet.read_byte!
       cap4 = packet.read_byte!
 
+      server_capabilities = cap1.to_u32 | (cap2.to_u32 << 8) | (cap3.to_u32 << 16) | (cap4.to_u32 << 24)
+
       auth_plugin_data_length = packet.read_byte!
       packet.read_byte_array(10)
       packet.read_fully(auth_data[8, {13, auth_plugin_data_length.to_i16 - 8}.max - 1])
       packet.read_byte!
-      packet.read_string
+      server_plugin_name = packet.read_string
 
-      HandshakeV10.new(auth_data, charset)
+      HandshakeV10.new(auth_data, charset, server_capabilities, server_plugin_name)
     end
   end
 

--- a/src/mysql/packets.cr
+++ b/src/mysql/packets.cr
@@ -75,7 +75,7 @@ module MySql::Protocol
 
     # https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_ssl_request.html
     def write_ssl_request(packet : MySql::WritePacket)
-      caps = Capability::Protocol41 | Capability::SSL
+      caps = Capability::Protocol41 | Capability::SSL | Capability::SecureConnection | Capability::PluginAuth | Capability::PluginAuthLenencClientData
       caps |= Capability::ConnectWithDB if @initial_catalog
 
       packet.write_bytes caps.value, IO::ByteFormat::LittleEndian
@@ -85,7 +85,7 @@ module MySql::Protocol
       23.times { packet.write_byte 0_u8 }
     end
 
-    def write(packet : MySql::WritePacket)
+    def write(packet : MySql::WritePacket, ssl_established : Bool = false)
       caps = Capability::Protocol41 | Capability::SecureConnection | Capability::PluginAuthLenencClientData | Capability::PluginAuth
       caps |= Capability::ConnectWithDB if @initial_catalog
 
@@ -97,7 +97,7 @@ module MySql::Protocol
       packet << @username
       packet.write_byte 0_u8
 
-      auth_response = Auth.compute_auth_response(@plugin_name, @password, @auth_plugin_data)
+      auth_response = Auth.compute_auth_response(@plugin_name, @password, @auth_plugin_data, ssl_established)
       if auth_response.empty?
         packet.write_byte 0_u8
       else

--- a/src/mysql/read_packet.cr
+++ b/src/mysql/read_packet.cr
@@ -1,7 +1,7 @@
 class MySql::ReadPacket < IO
   getter remaining : Int32 = 0
+  getter seq : UInt8 = 0u8
   @length : Int32 = 0
-  @seq : UInt8 = 0u8
 
   def initialize(@io : IO, @connection : Connection)
     @length = 0

--- a/src/mysql/read_packet.cr
+++ b/src/mysql/read_packet.cr
@@ -1,6 +1,6 @@
 class MySql::ReadPacket < IO
+  getter remaining : Int32 = 0
   @length : Int32 = 0
-  @remaining : Int32 = 0
   @seq : UInt8 = 0u8
 
   def initialize(@io : IO, @connection : Connection)


### PR DESCRIPTION
## Summary

- Add support for `caching_sha2_password` (MySQL 8.0+ default), `sha256_password`, and `mysql_clear_password` auth plugins
- Implement `AuthSwitchRequest` handling so the client works when a user's auth plugin differs from the server default
- Add RSA public key exchange for full authentication without TLS (`caching_sha2_password` and `sha256_password`)
- Refactor capability constants to `@[Flags] enum Capability : UInt32`
- Extend `HandshakeV10` to capture `server_capabilities` and `server_plugin_name`

## Auth plugins supported

| Plugin | Mechanism |
|--------|-----------|
| `mysql_native_password` | SHA1 challenge-response (existing, refactored) |
| `caching_sha2_password` | SHA256 fast path + full auth (TLS or RSA) |
| `sha256_password` | Full auth only (TLS or RSA) |
| `mysql_clear_password` | Plaintext over TLS |

## Test plan

Docker-based manual test suite covering 13 scenarios across 5 MySQL/MariaDB containers:

```bash
docker compose -f docker-compose.auth-test.yml up -d
# wait ~15s
spec/manual/run_auth_tests.sh
```

Containers:
- `mysql57` (port 13306) — native password default
- `mysql80` (port 13307) — caching_sha2 default, TLS
- `mysql80_native` (port 13308) — native default, auth switch scenarios
- `mysql90` (port 13309) — native removed, caching_sha2 only
- `mariadb` (port 13310) — MariaDB 11 compatibility

All 13 manual auth tests pass. Existing spec suite (802 examples) passes with zero regressions against mysql57, mysql80, mysql80_native, mysql90, and mariadb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)